### PR TITLE
Add relations from FulfilmentMethod to TypeOfTravelDocuments to distinguish issuing from reuse of a TravelDocument

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesDistribution_version.xsd
@@ -377,6 +377,16 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>TYPES OF TRAVEL DOCUMENT associated with method.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="canIssueTypesOfTravelDocument" type="TypeOfTravelDocumentRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TYPES OF TRAVEL DOCUMENT that can be ISSUED with method.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="canReuseTypesOfTravelDocument" type="TypeOfTravelDocumentRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>TYPES OF TRAVEL DOCUMENT that can be REUSED with method.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="prices" type="fulfilmentMethodPrices_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Prices for FULFILMENT METHOD.</xsd:documentation>


### PR DESCRIPTION
Add 2 new relations from FulfilmentMethod to TypeOfTravelDocuments to distinguish between issuing of of a new travel document opposed to reusing an existing one