### PR TITLE
Make MainPartRef non-mandatory for JourneyPart (JourneyPartGroup)

### DIFF
--- a/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_coupledJourney_version.xsd
@@ -207,7 +207,7 @@ of the corresponding VEHICLE TYPE. true for forward.</xsd:documentation>
 			<xsd:documentation>Reference Elements for JOURNEY PART.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="MainPartRef" type="JourneyPartCoupleRefStructure">
+			<xsd:element name="MainPartRef" type="JourneyPartCoupleRefStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Main JOURNEY PART for journey.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
When e.g. changing Train Number due to bordercrossing there is no need to divide the vehicle, but you may still want to split the journey into parts. In this use-case there is no “Main Part” thus no point in defining or referencing it.
_Change is fully backwards compliant_