### PR TITLE
Add support for NAND, NOR, XNOR as a LogicalOperation. 

### DIFF
--- a/xsd/netex_framework/netex_responsibility/netex_validityCondition_support.xsd
+++ b/xsd/netex_framework/netex_responsibility/netex_validityCondition_support.xsd
@@ -95,9 +95,9 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:simpleType name="BooleanOperatorEnumeration">
+	<xsd:simpleType name="LogicalOperationEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Allowed values for Boolean operations.</xsd:documentation>
+			<xsd:documentation>Allowed values for logical operations. See https://en.wikipedia.org/wiki/Logic_gate</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="AND">
@@ -107,17 +107,32 @@ Rail transport, Roads and Road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="OR">
 				<xsd:annotation>
-					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy at least one  specified value.</xsd:documentation>
+					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy at least one specified value.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="NOT">
 				<xsd:annotation>
-					<xsd:documentation>Specified elements  must be different from the given value.</xsd:documentation>
+					<xsd:documentation>Specified elements must be different from the given value. If the number of specified elements is equal to 1, the function negates it. If the number of specified elements > 1, this operator is equal to the NOR operator</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="XOR">
 				<xsd:annotation>
-					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy only one  specified value.</xsd:documentation>
+					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy only one specified value.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="NAND">
+				<xsd:annotation>
+					<xsd:documentation>Successive elements are logically ANDed together; comparison must satisfy all specified values. The result is then negated.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="NOR">
+				<xsd:annotation>
+					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy at least one specified value. The result is then negated.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="XNOR">
+				<xsd:annotation>
+					<xsd:documentation>Successive elements are logically ORed together; comparison must satisfy only one specified value. The result is then negated.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -263,7 +263,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Limiting USAGE PARAMETER Elements or ACCESS RIGHT PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="LimitationGroupingType" type="BooleanOperatorEnumeration" default="AND" minOccurs="0">
+			<xsd:element name="LimitationGroupingType" type="LogicalOperationEnumeration" default="AND" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Operator for Grouping Scope Elements: logical OR, AND, NOT. Default is AND.</xsd:documentation>
 				</xsd:annotation>
@@ -286,7 +286,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Comparison Operator for comparing Validity Erlements valeus. Defalut is EQ.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ValidityParameterGroupingType" type="BooleanOperatorEnumeration" default="AND" minOccurs="0">
+			<xsd:element name="ValidityParameterGroupingType" type="LogicalOperationEnumeration" default="AND" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Operator for Grouping Scope Elements: logical OR, AND, NOT. Default is AND.</xsd:documentation>
 				</xsd:annotation>
@@ -732,7 +732,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for compound GENERIC PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="IncludesGroupingType" type="BooleanOperatorEnumeration" default="OR" minOccurs="0">
+			<xsd:element name="IncludesGroupingType" type="LogicalOperationEnumeration" default="OR" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Operator for Grouping Scope Elements. Default is OR.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -458,7 +458,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for Compound SPECIFIC PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="IncludesGroupingType" type="BooleanOperatorEnumeration" default="OR" minOccurs="0">
+			<xsd:element name="IncludesGroupingType" type="LogicalOperationEnumeration" default="OR" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Operator for Grouping Scope Elements. Default is OR.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
Also renamed `BooleanOperatorEnumeration` to `LogicalOperationEnumeration` to better reflect actual use

https://en.wikipedia.org/wiki/Logic_gate