### PR TITLE
Remove typo 'r' in noticeAssignments

### DIFF
--- a/xsd/netex_part_1/part1_ifopt/netex_assistanceBooking_version.xsd
+++ b/xsd/netex_part_1/part1_ifopt/netex_assistanceBooking_version.xsd
@@ -135,7 +135,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="BookingContact" type="ContactStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>Contact details for  ASSISTANCE BOOKING SERVICE.</xsd:documentation>
+					<xsd:documentation>Contact details for ASSISTANCE BOOKING SERVICE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="BookingArrangements" type="BookingArrangementsStructure" minOccurs="0">
@@ -148,9 +148,9 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Reference Elements for ASSISTANCE BOOKING SERVICE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
-			<xsd:element name="noticeAssignmenrts" type="noticeAssignments_RelStructure" minOccurs="0">
+			<xsd:element name="noticeAssignments" type="noticeAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>NOTICEs  for ASSISTANCE BOOKING SERVICE.</xsd:documentation>
+					<xsd:documentation>NOTICEs for ASSISTANCE BOOKING SERVICE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
See line 151

Additionally corrected some minor formatting issues (indentation, removed double spaces).