### PR TITLE
Allow referencing ServiceCalendar intemporal validity parameters assignment (REPLACED BY PR#22)

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_support.xsd
@@ -13,10 +13,10 @@
 					<Created>2010-09-04</Created>
 				</Date>
 				<Date>
-					<Modified>2014-03-31</Modified>
+					<Modified>2020-12-08</Modified>FIX - Add UicOperatingPeriodRef
 				</Date>
 				<Description>
-					<p>NeTEx - Network Exchange. This subschema defines  SERVICE CALENDAR identifier  types.</p>
+					<p>NeTEx - Network Exchange. This subschema defines SERVICE CALENDAR identifier  types.</p>
 				</Description>
 				<Format>
 					<MediaType>text/xml</MediaType>

--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_support.xsd
@@ -131,6 +131,32 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
+	<xsd:simpleType name="UicOperatingPeriodIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of an UIC OPERATING PERIOD.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="UicOperatingPeriodRef" type="UicOperatingPeriodRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an UIC OPERATING PERIOD.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UicOperatingPeriodRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an UIC OPERATING PERIOD.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="UicOperatingPeriodIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an UIC OPERATING PERIOD.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
 	<xsd:simpleType name="DayTypeAssignmentIdType">
 		<xsd:annotation>
 			<xsd:documentation>Identifier of a  DAY TYPE ASSIGNMENT.</xsd:documentation>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -330,9 +330,12 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TimebandRef" minOccurs="0"/>
 			<xsd:element ref="GroupOfTimebandsRef" minOccurs="0"/>
 			<xsd:element ref="OperatingDayRef" minOccurs="0"/>
-			<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>
-			<xsd:element ref="ValidityConditionRef" minOccurs="0"/>
+			<xsd:choice>
+				<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>
+				<xsd:element ref="UicOperatingPeriodRef" minOccurs="0"/>
+			</xsd:choice>
 			<xsd:element ref="ServiceCalendarRef" minOccurs="0"/>
+			<xsd:element ref="ValidityConditionRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:complexType name="validityParameters_RelStructure">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -331,6 +331,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="OperatingDayRef" minOccurs="0"/>
 			<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>
 			<xsd:element ref="ValidityConditionRef" minOccurs="0"/>
+			<xsd:element ref="ServiceCalendarRef" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:complexType name="validityParameters_RelStructure">

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -62,7 +62,7 @@
 				</Date>
 				<Date>
 					<Modified>2019-03-01</Modified>Add missing elements to GenericParameterAssignment
-					    *	UK-33 Add TariffRef	as a GenericParameterAssignment parameter
+					    *	UK-33 Add TariffRef as a GenericParameterAssignment parameter
 					   *	UK80 TypeOfConcession, TypeOfUsageParameter,  VehicleType   TypeOfLineRef as GenericParameterAssignment parameters
 				</Date>
 				<Date>
@@ -75,21 +75,23 @@
 					<Modified>2019-03-09</Modified>EURA-54 Add a PassengerSeatRef to
 				</Date>
 				<Date>
-					<Modified>2019-03-14</Modified>UK-41  Also LimitationSelectionType Add an additional functional operator to GenericParameterAssignment  to clarify use of groups :  oneOf /  someOf/  allOf
-
+					<Modified>2019-03-14</Modified>UK-41  Also LimitationSelectionType Add an additional functional operator to GenericParameterAssignment  to clarify use of groups :  oneOf / someOf / allOf
 					* Add  new ___FareStructureValidityParametersGroup___ to validity paarmaters with new attributes   ___TypeOfTariffRef___,   ___TypeOfFareStructureFactor___,  ___TypeOfFarFresStructureFactorRef___,
-					  * Extend  ___FareProduct ValidityParametersGroup___  to validity paramaters  with new attributes   ___TypeOfPriceingRuleRef___,   ___ChargingMethodRef___, ___TypeOfPaymentMethodRef___, ___TypeOfMachineReadability___, ___TypeOfFareTableRef.___  TypeofMachineReadabilityRef.
-					  * Add  new ___SeatingValidityParametersGroup___ with new attributes   ___TrainElementRef___,    ___TrainComponentLabelAssignmentRef___.
-					 * Also add OperatingPeriod Ref to Temporal  validity Parameters
-					 * Also Fix change choice of TrainNumber etc to selection,
+					* Extend  ___FareProduct ValidityParametersGroup___  to validity paramaters  with new attributes   ___TypeOfPriceingRuleRef___,   ___ChargingMethodRef___, ___TypeOfPaymentMethodRef___, ___TypeOfMachineReadability___, ___TypeOfFareTableRef.___  TypeofMachineReadabilityRef.
+					* Add  new ___SeatingValidityParametersGroup___ with new attributes   ___TrainElementRef___,    ___TrainComponentLabelAssignmentRef___.
+					* Also add OperatingPeriod Ref to Temporal  validity Parameters
+					* Also Fix change choice of TrainNumber etc to selection,
 				</Date>
 				<Date>
 					<Modified>2019-03-26</Modified>NL-27 CD #58 Add default TypeOfProductCategory and TypeOfService to Line:
 					Move TypeOfProductCategory amnd TypeOfService from netex_journey_version  to  Framework reusable components (netex_travelRights_version)  so they are visible from part 1
-		  	Can  therefore drop include of netex_travelRights_version from 	  netex_accessRightParameter_version.xsd  .
+		  	Can  therefore drop include of netex_travelRights_version from netex_accessRightParameter_version.xsd.
 				</Date>
 				<Date>
-					<Modified>2019-04-18</Modified>FIX  - SUpport Place to Place travel (ADDRESS and TOPOGRAPHICAL PLACE) : Add AddressRef ,  TopoographiPlaceRef and PlaceUseEnum.
+					<Modified>2019-04-18</Modified>FIX - Support Place to Place travel (ADDRESS and TOPOGRAPHICAL PLACE): Add AddressRef ,  TopoographiPlaceRef and PlaceUseEnum.
+				</Date>
+				<Date>
+					<Modified>2020-12-08</Modified>FIX - Add optional TimebandRef, UicOperatingPeriodRef and ServiceCalendarRef to TemporalValidityParametersGroup
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -330,10 +332,8 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TimebandRef" minOccurs="0"/>
 			<xsd:element ref="GroupOfTimebandsRef" minOccurs="0"/>
 			<xsd:element ref="OperatingDayRef" minOccurs="0"/>
-			<xsd:choice>
-				<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>
-				<xsd:element ref="UicOperatingPeriodRef" minOccurs="0"/>
-			</xsd:choice>
+			<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>
+			<xsd:element ref="UicOperatingPeriodRef" minOccurs="0"/>
 			<xsd:element ref="ServiceCalendarRef" minOccurs="0"/>
 			<xsd:element ref="ValidityConditionRef" minOccurs="0"/>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -45,25 +45,25 @@
 					<Created>2010-09-04</Created>
 				</Date>
 				<Date>
-					<Modified>2011-02-05</Modified>Name Space changes 
+					<Modified>2011-02-05</Modified>Name Space changes
 				</Date>
 				<Date>
 					<Modified>2017-03-28</Modified> CR019 Make ValidityParameter Assignment not abstract and fix ambiguity with Generic Parameter
 				</Date>
 				<Date>
 					<Modified>2017-10-10</Modified> Fix Add TypeOfTravelDocument to ProductValidityParametersGroup.
-						* Allow DistanceMatrixElement view so that origin and Destination can be referenced 
+						* Allow DistanceMatrixElement view so that origin and Destination can be referenced
 				</Date>
 				<Date>
-					<Modified>2017-10-10</Modified> Fix Add TimeIntervalRef TimeStructureFactorRef to GeographicalIntervalRef   GeographicalStructureFactorRef to be referenced 
+					<Modified>2017-10-10</Modified> Fix Add TimeIntervalRef TimeStructureFactorRef to GeographicalIntervalRef   GeographicalStructureFactorRef to be referenced
 				</Date>
 				<Date>
 					<Modified>2019-03-01</Modified>EURA-(nk) Add DistanceMatrixInverseRef for backwards direction of reference to a DIstance Matrix Element
 				</Date>
 				<Date>
-					<Modified>2019-03-01</Modified>Add missing elements to GenericParameterAssignment 
-					    *	UK-33 Add TariffRef	as a GenericParameterAssignment parameter	
-					   *	UK80 TypeOfConcession, TypeOfUsageParameter,  VehicleType   TypeOfLineRef as GenericParameterAssignment parameters					 
+					<Modified>2019-03-01</Modified>Add missing elements to GenericParameterAssignment
+					    *	UK-33 Add TariffRef	as a GenericParameterAssignment parameter
+					   *	UK80 TypeOfConcession, TypeOfUsageParameter,  VehicleType   TypeOfLineRef as GenericParameterAssignment parameters
 				</Date>
 				<Date>
 					<Modified>2019-03-01</Modified>EURA-88 Add ServiceMatch Attributes : Exact | next | previous | timebands  to GenericParameterAssignmen
@@ -72,20 +72,20 @@
 					<Modified>2019-03-01</Modified>UK-41 Add an additional functional operator to GenericParameterAssignment  to clarify use of groups :  oneOf /  someOf/  allOf
 				</Date>
 				<Date>
-					<Modified>2019-03-09</Modified>EURA-54 Add a PassengerSeatRef to 
+					<Modified>2019-03-09</Modified>EURA-54 Add a PassengerSeatRef to
 				</Date>
 				<Date>
 					<Modified>2019-03-14</Modified>UK-41  Also LimitationSelectionType Add an additional functional operator to GenericParameterAssignment  to clarify use of groups :  oneOf /  someOf/  allOf
-					
-					* Add  new ___FareStructureValidityParametersGroup___ to validity paarmaters with new attributes   ___TypeOfTariffRef___,   ___TypeOfFareStructureFactor___,  ___TypeOfFarFresStructureFactorRef___,   
+
+					* Add  new ___FareStructureValidityParametersGroup___ to validity paarmaters with new attributes   ___TypeOfTariffRef___,   ___TypeOfFareStructureFactor___,  ___TypeOfFarFresStructureFactorRef___,
 					  * Extend  ___FareProduct ValidityParametersGroup___  to validity paramaters  with new attributes   ___TypeOfPriceingRuleRef___,   ___ChargingMethodRef___, ___TypeOfPaymentMethodRef___, ___TypeOfMachineReadability___, ___TypeOfFareTableRef.___  TypeofMachineReadabilityRef.
-					  * Add  new ___SeatingValidityParametersGroup___ with new attributes   ___TrainElementRef___,    ___TrainComponentLabelAssignmentRef___.  
-					 * Also add OperatingPeriod Ref to Temporal  validity Parameters 
-					 * Also Fix change choice of TrainNumber etc to selection, 
+					  * Add  new ___SeatingValidityParametersGroup___ with new attributes   ___TrainElementRef___,    ___TrainComponentLabelAssignmentRef___.
+					 * Also add OperatingPeriod Ref to Temporal  validity Parameters
+					 * Also Fix change choice of TrainNumber etc to selection,
 				</Date>
 				<Date>
 					<Modified>2019-03-26</Modified>NL-27 CD #58 Add default TypeOfProductCategory and TypeOfService to Line:
-					Move TypeOfProductCategory amnd TypeOfService from netex_journey_version  to  Framework reusable components (netex_travelRights_version)  so they are visible from part 1	
+					Move TypeOfProductCategory amnd TypeOfService from netex_journey_version  to  Framework reusable components (netex_travelRights_version)  so they are visible from part 1
 		  	Can  therefore drop include of netex_travelRights_version from 	  netex_accessRightParameter_version.xsd  .
 				</Date>
 				<Date>
@@ -327,6 +327,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="DayTypeRef" minOccurs="0"/>
+			<xsd:element ref="TimebandRef" minOccurs="0"/>
 			<xsd:element ref="GroupOfTimebandsRef" minOccurs="0"/>
 			<xsd:element ref="OperatingDayRef" minOccurs="0"/>
 			<xsd:element ref="OperatingPeriodRef" minOccurs="0"/>


### PR DESCRIPTION
And not just smaller pieces like operating period/day etc