### PR TITLE
Remove trailing space in FareClassEnumeration secondClass

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_serviceRestrictions_support.xsd
@@ -116,7 +116,7 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>pti23_6</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
-			<xsd:enumeration value="secondClass ">
+			<xsd:enumeration value="secondClass">
 				<xsd:annotation>
 					<xsd:documentation>pti23_7</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
This causes parsing issues in the NeTEx Java model