### PR TITLE
Add DynamicDistanceMatrixElement

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -16,7 +16,7 @@
 	<xsd:include schemaLocation="netex_fareStructureElement_support.xsd"/>
 	<xsd:include schemaLocation="netex_qualityStructureFactor_support.xsd"/>
 	<xsd:include schemaLocation="netex_timeStructureFactor_support.xsd"/>
-	<xsd:include schemaLocation="netex_distanceMatrixElement_support.xsd"/>
+	<xsd:include schemaLocation="netex_distanceMatrixElement_version.xsd"/>
 	<xsd:include schemaLocation="netex_usageParametersAll_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd"/>
 	<xsd:include schemaLocation="netex_fareProduct_support.xsd"/>
@@ -250,7 +250,10 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="TariffRef" minOccurs="0"/>
 			<xsd:element ref="FareStructureElementRef" minOccurs="0"/>
 			<xsd:element ref="FareElementInSequenceRef" minOccurs="0"/>
-			<xsd:element ref="DistanceMatrixElementRef" minOccurs="0"/>
+			<xsd:choice  minOccurs="0">
+				<xsd:element ref="DistanceMatrixElementRef"/>
+				<xsd:element ref="DynamicDistanceMatrixElement"/>
+			</xsd:choice>
 			<xsd:element ref="DistanceMatrixElementInverseRef" minOccurs="0"/>
 			<xsd:element ref="DistanceMatrixElementView" minOccurs="0"/>
 			<xsd:element ref="SalesOfferPackageRef" minOccurs="0"/>

--- a/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_distanceMatrixElement_version.xsd
@@ -31,7 +31,10 @@
 				</Date>
 				<Date>
 					<Modified>2019-03-25</Modified>Fix #40 by Skinkie from 2019.01.07 . Fix typo on DistanceMatrixElement.IsDirect.  
-					 NB this will break existing XML that uses IsDirect. 
+					NB this will break existing XML that uses IsDirect. 
+				</Date>
+				<Date>
+					<Modified>2021-02-05</Modified>Add DynamicDistanceMatrixElement for on-the-fly creation when pre-computing all possible combinations is not feasible
 				</Date>
 				<Description>
 					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
@@ -479,6 +482,13 @@ Rail transport, Roads and Road transport
 		</xsd:choice>
 	</xsd:group>
 	<!-- ======================================================================= -->
+
+	<xsd:element name="DynamicDistanceMatrixElement" type="DistanceMatrixElement_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>A dynamic free-standing distance matrix element. Used when a pre-computed distance matrix element is not feasible.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
 	<!-- == DISTANCE MATRIX ELEMENT View-->
 	<xsd:element name="DistanceMatrixElementView" type="DistanceMatrixElement_DerivedViewStructure" abstract="false" substitutionGroup="DerivedView">
 		<xsd:annotation>


### PR DESCRIPTION
- Used for on-the-fly generation when pre-computing all possible combinations is not feasible
- Add choice to have embedded DynamicDistanceMatrixElement in ParameterAssignmentScopeGroup

Added in agreement with Nick

Replaces #12 (must be reverted). 

Replaces https://github.com/NeTEx-CEN/NeTEx/pull/124 