### PR TITLE
WIP: Add usage dependency structures across multiple SalesOfferPackageElements/CustomerPurchasePackageElements

### DIFF
--- a/consumption_dependencies.plantuml
+++ b/consumption_dependencies.plantuml
@@ -1,0 +1,206 @@
+@startuml
+title Consumption dependencies between CPPEs
+
+package "Sales offer package model" {
+	class SalesOfferPackage
+	class SalesOfferPackageElement
+	class FareProduct
+	class ValidableElement
+	class AccessRightInProduct  {
+		-int maximumAccess // number of instances of validableElement
+	}
+	class FareStructureElement
+	class GenericParameterAssignment
+
+	SalesOfferPackage "1" *-- "1..n" SalesOfferPackageElement: "salesOfferPackageElements"
+	SalesOfferPackageElement "1" *-- "1" FareProduct: "salesOfferPackageElements"
+	FareProduct  "1" *-- "1..n" AccessRightInProduct : "accessRightInProduct"
+	AccessRightInProduct  "1" *-- "1..n" ValidableElement : "validableElement (number defined by MaximumAccess)"
+	ValidableElement  "1" *-- "1..n" FareStructureElement : "fareStructureElements"
+	SalesOfferPackageElement "1" *-- "0..n" GenericParameterAssignment: "validityParameterAssignments"
+	FareProduct "1" *-- "0..n" GenericParameterAssignment: "validityParameterAssignments"
+	ValidableElement "1" *-- "0..n" GenericParameterAssignment: "validityParameterAssignments"
+	FareStructureElement "1" *-- "0..n" GenericParameterAssignment: "validityParameterAssignments"
+}
+
+package "Customer purchase package model" {
+	class CustomerPurchasePackage
+	class CustomerPurchasePackageElement
+	class CustomerPurchasePackageElementAccess
+	class CustomerPurchaseParameterAssignment
+
+	CustomerPurchasePackage "1" *-- "1..n" CustomerPurchasePackageElement: "customerPurchasePackageElements"
+	CustomerPurchasePackageElement "1" *-- "0..n" CustomerPurchasePackageElementAccess: "elementAccesses"
+	CustomerPurchasePackageElement "1" *-- "0..n" CustomerPurchaseParameterAssignment: "validityParameterAssignments"
+
+	enum MarkedAs {
+		-unused
+		-activated
+		-used
+		-marked
+		-expired
+	}
+}
+
+package "Access right parameter model" {
+	class ValidityParameterAssignment
+
+	ValidityParameterAssignment <|-- CustomerPurchaseParameterAssignment
+	ValidityParameterAssignment <|-- GenericParameterAssignment
+
+}
+
+
+package "Consumption dependency model" {
+	note top of ConsumptionUtilisationDependency
+		Describes a dependency that one or more CustomerPurchasePackageElementAccess
+		for a given CustomerPurchasePackageElement must be in the state defined by MarkedAs
+		in order for elements listed in ConsumptionUtilisation to proceed state changes
+		(defined using CPPAs with TypeOfAccessRightParameterAssignment=xxxPolicyAssignment inside the corresponding CPPE)
+	end note
+	class ConsumptionUtilisationDependency #lightblue
+
+
+
+
+	note top of ConsumptionDependency
+		Defines the state the corresponding
+		CustomerPurchasePackageElementAccess
+		must be in in order for dependency to be satisfied
+	end note
+	class ConsumptionDependency #lightblue
+
+	note bottom of CustomerPurchasePackageElementConsumptionDependency
+		Specialisation referring to an CPPE.
+		Used in the CustomerPurchasePackage hierarchy
+	end note
+	class CustomerPurchasePackageElementConsumptionDependency #lightblue
+
+
+	note bottom of AccessRightInProductConsumptionDependency
+		Specialisation referring to an AccessRightInProduct with
+		a given access number (used if MaximumAccess > 1)
+	end note
+	class AccessRightInProductConsumptionDependency #lightblue {
+		-int accessNumber
+	}
+	ConsumptionDependency <|-- CustomerPurchasePackageElementConsumptionDependency
+	ConsumptionDependency <|-- AccessRightInProductConsumptionDependency
+
+	AccessRightInProductConsumptionDependency --> AccessRightInProduct
+	CustomerPurchasePackageElementConsumptionDependency --> CustomerPurchasePackageElement
+
+
+
+
+	note bottom of CrossConstraint
+		Defines a constraint accross multiple
+		parameter assigments.
+		This is used to ensure that 2 or more
+		ValidityParameterAssignment
+		(TypeOfAccessRightParameterAssignment=SpecificationPolicyAssignment)
+		must receive the same Journey-details when activating/consuming the element
+	end note
+	class CrossConstraint #lightblue{
+	}
+
+
+
+
+
+	note top of ConsumptionUtilisation
+		The CPPE/AccessRightInProduct that is affected when
+		dependency is satisfied
+	end note
+	class ConsumptionUtilisation #lightblue
+
+	note bottom of CustomerPurchasePackageElementConsumptionUtilisation
+		Specialisation referring to a CustomerPurchasePackageElement
+	end note
+	class CustomerPurchasePackageElementConsumptionUtilisation #lightblue
+
+	note bottom of AccessRightInProductConsumptionUtilisation
+		Specialisation referring to an AccessRightInProduct with
+		a given access number (used if MaximumAccess > 1)
+	end note
+	class AccessRightInProductConsumptionUtilisation #lightblue {
+		-int accessNumber
+	}
+	ConsumptionUtilisation <|-- CustomerPurchasePackageElementConsumptionUtilisation
+	ConsumptionUtilisation <|-- AccessRightInProductConsumptionUtilisation
+
+
+	CustomerPurchasePackageElementConsumptionUtilisation "1" --> "1" CustomerPurchasePackageElement: "cppe in question"
+	AccessRightInProductConsumptionUtilisation "1" --> "1" AccessRightInProduct: "access right in question"
+
+
+
+
+
+	ConsumptionDependency "1" --> "1" CustomerPurchasePackageElement: "cppe in question"
+	ConsumptionDependency "1" --> "1" MarkedAs: "markedAs status"
+	CustomerPurchasePackageElementConsumptionUtilisation  .. CustomerPurchasePackageElementAccess: "element access in state"
+
+	note top of MaximumNumberOfAccesses
+		Maximum number the CPPE can be transitioned
+		Overall value for all listed ConsumptionUtilisation
+	end note
+	class MaximumNumberOfAccesses #lightblue {
+		-integer value
+	}
+	note bottom of MaximumNumberOfAccessesType
+		Either limited with a given value
+		or unlimited
+	end note
+	enum MaximumNumberOfAccessesType #lightblue {
+		-limited
+		-unlimited
+	}
+	MaximumNumberOfAccesses *--  MaximumNumberOfAccessesType: "type"
+
+
+	note top of ConsumptionTransitionPolicy
+		Shall the coresponding CPPE referred to in ConsumptionUtilisation
+		be transitioned automatically (according to CPPE parameters)
+		or manually at the convenience of the traveller/external system
+	end note
+	enum ConsumptionTransitionPolicy #lightblue{
+		-manual
+		-automatic
+	}
+
+	CustomerPurchasePackage "1" *-- "0..n" ConsumptionUtilisationDependency: "consumptionUtilisationDependencies"
+	SalesOfferPackage "1" *-- "0..n" ConsumptionUtilisationDependency: "consumptionUtilisationDependencies"
+
+
+
+
+	ConsumptionUtilisationDependency "1" *-- "0..n" ConsumptionDependency: "consumptionDependencies"
+	ConsumptionUtilisationDependency *--  MaximumNumberOfAccesses: "maximumNumberOfAccesses"
+	ConsumptionUtilisationDependency "1" *-- "0..n" ConsumptionUtilisation: "consumptionUtilisations"
+	ConsumptionUtilisationDependency "1" *-- "0..n" CrossConstraint: "crossConstraints"
+	ConsumptionUtilisationDependency *--  LogicalOperatorEnumeration: "consumptionDependenciesGrouping"
+	ConsumptionUtilisationDependency *--  LogicalOperatorEnumeration: "consumptionUtilisationGrouping"
+	ConsumptionUtilisationDependency *--  ConsumptionTransitionPolicy: "transitionPolicy"
+
+
+	class EntitlementConstraintStructure {
+		-JourneyConstraint journeyConstraint
+		-...
+	}
+
+	CrossConstraint  *--  EntitlementConstraintStructure: "constraint"
+	CrossConstraint "1" *-- "2..n" ValidityParameterAssignment: "validityParameterAssignments"
+
+	enum LogicalOperatorEnumeration {
+		-AND
+		-OR
+		-XOR
+		-NOT
+		-NAND
+		-NOR
+		-XNOR
+	}
+
+}
+@enduml

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -9246,48 +9246,48 @@
 			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- =====Consumption============================== -->
-		<!-- =====ConsumptionUtilisationDependency unique========================== -->
-		<xsd:unique name="ConsumptionUtilisationDependency_UniqueBy_Id_Version">
+		<!-- =====ConsumptionDependency unique========================== -->
+		<xsd:unique name="ConsumptionDependency_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [ConsumptionUtilisationDependency Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [ConsumptionDependency Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:ConsumptionUtilisationDependency"/>
+			<xsd:selector xpath=".//netex:ConsumptionDependency"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
-		<!-- =====CustomerPurchasePackageElementConsumptionDependency unique========================== -->
-		<xsd:unique name="CustomerPurchasePackageElementConsumptionDependency_UniqueBy_Id_Version">
+		<!-- =====CustomerPurchasePackageElementConsumptionRequirement unique========================== -->
+		<xsd:unique name="CustomerPurchasePackageElementConsumptionRequirement_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [CustomerPurchasePackageElementConsumptionDependency Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [CustomerPurchasePackageElementConsumptionRequirement Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:CustomerPurchasePackageElementConsumptionDependency"/>
+			<xsd:selector xpath=".//netex:CustomerPurchasePackageElementConsumptionRequirement"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
-		<!-- =====AccessRightInProductConsumptionDependency unique========================== -->
-		<xsd:unique name="AccessRightInProductConsumptionDependency_UniqueBy_Id_Version">
+		<!-- =====AccessRightInProductConsumptionRequirement unique========================== -->
+		<xsd:unique name="AccessRightInProductConsumptionRequirement_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [AccessRightInProductConsumptionDependency Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [AccessRightInProductConsumptionRequirement Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:AccessRightInProductConsumptionDependency"/>
+			<xsd:selector xpath=".//netex:AccessRightInProductConsumptionRequirement"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
-		<!-- =====CustomerPurchasePackageElementConsumptionUtilisation unique========================== -->
-		<xsd:unique name="CustomerPurchasePackageElementConsumptionUtilisation_UniqueBy_Id_Version">
+		<!-- =====CustomerPurchasePackageElementConsumption unique========================== -->
+		<xsd:unique name="CustomerPurchasePackageElementConsumption_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [CustomerPurchasePackageElementConsumptionUtilisation Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [CustomerPurchasePackageElementConsumption Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:CustomerPurchasePackageElementConsumptionUtilisation"/>
+			<xsd:selector xpath=".//netex:CustomerPurchasePackageElementConsumption"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
-		<!-- =====AccessRightInProductConsumptionUtilisation unique========================== -->
-		<xsd:unique name="AccessRightInProductConsumptionUtilisation_UniqueBy_Id_Version">
+		<!-- =====AccessRightInProductConsumption unique========================== -->
+		<xsd:unique name="AccessRightInProductConsumption_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [AccessRightInProductConsumptionUtilisation Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [AccessRightInProductConsumption Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:AccessRightInProductConsumptionUtilisation"/>
+			<xsd:selector xpath=".//netex:AccessRightInProductConsumption"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -8251,6 +8251,26 @@
 			<xsd:field xpath="@version"/>
 			<xsd:field xpath="@order"/>
 		</xsd:key>
+		<!-- =====GroupOfCustomerPurchaseParameterAssignments unique========================== -->
+		<xsd:unique name="GroupOfCustomerPurchaseParameterAssignments_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [GroupOfCustomerPurchaseParameterAssignments Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:GroupOfCustomerPurchaseParameterAssignments"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====ValidityParameterAssignmentRef Key ========================== -->
+		<xsd:keyref name="ValidityParameterAssignment_KeyRef" refer="netex:ValidityParameterAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:ValidityParameterAssignmentRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="ValidityParameterAssignment_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:CustomerPurchaseParameterAssignment | .//netex:GenericParameterAssignment"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- =====TypeOfAccessRightAssignment============================== -->
 		<!-- =====TypeOfAccessRightAssignment unique========================== -->
 		<xsd:unique name="TypeOfAccessRightAssignment_UniqueBy_Id_Version">
@@ -9225,6 +9245,61 @@
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- =====Consumption============================== -->
+		<!-- =====ConsumptionUtilisationDependency unique========================== -->
+		<xsd:unique name="ConsumptionUtilisationDependency_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [ConsumptionUtilisationDependency Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:ConsumptionUtilisationDependency"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====CustomerPurchasePackageElementConsumptionDependency unique========================== -->
+		<xsd:unique name="CustomerPurchasePackageElementConsumptionDependency_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [CustomerPurchasePackageElementConsumptionDependency Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:CustomerPurchasePackageElementConsumptionDependency"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====AccessRightInProductConsumptionDependency unique========================== -->
+		<xsd:unique name="AccessRightInProductConsumptionDependency_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [AccessRightInProductConsumptionDependency Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:AccessRightInProductConsumptionDependency"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====CustomerPurchasePackageElementConsumptionUtilisation unique========================== -->
+		<xsd:unique name="CustomerPurchasePackageElementConsumptionUtilisation_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [CustomerPurchasePackageElementConsumptionUtilisation Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:CustomerPurchasePackageElementConsumptionUtilisation"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====AccessRightInProductConsumptionUtilisation unique========================== -->
+		<xsd:unique name="AccessRightInProductConsumptionUtilisation_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [AccessRightInProductConsumptionUtilisation Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:AccessRightInProductConsumptionUtilisation"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<!-- =====CrossConstraint unique========================== -->
+		<xsd:unique name="CrossConstraint_UniqueBy_Id_Version">
+			<xsd:annotation>
+				<xsd:documentation>Every [CrossConstraint Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:CrossConstraint"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
 	</xsd:element>
 	<!-- =====END OF CONSTRAINTS================= -->
 	<xsd:complexType name="PublicationDeliveryStructure">

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -7621,7 +7621,7 @@
 		</xsd:unique>
 		<!-- =====FareZone Key ========================== -->
 		<xsd:keyref name="FareZone_KeyRef" refer="netex:FareZone_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:FareZoneRef | .//netex:FromFareZoneRef | .//netex:ToFareZoneRef   |.//netex:ProjectedObjectRef"/>
+			<xsd:selector xpath=".//netex:FareZoneRef | .//netex:ParentFareZoneRef | .//netex:FromFareZoneRef | .//netex:ToFareZoneRef   |.//netex:ProjectedObjectRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -9246,12 +9246,12 @@
 			<xsd:field xpath="@version"/>
 		</xsd:key>
 		<!-- =====Consumption============================== -->
-		<!-- =====ConsumptionDependency unique========================== -->
-		<xsd:unique name="ConsumptionDependency_UniqueBy_Id_Version">
+		<!-- =====ElementConsumptionPolicy unique========================== -->
+		<xsd:unique name="ElementConsumptionPolicy_UniqueBy_Id_Version">
 			<xsd:annotation>
-				<xsd:documentation>Every [ConsumptionDependency Id + Version] must be unique within document.</xsd:documentation>
+				<xsd:documentation>Every [ElementConsumptionPolicy Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:ConsumptionDependency"/>
+			<xsd:selector xpath=".//netex:ElementConsumptionPolicy"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
@@ -28,8 +28,8 @@
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: CONSUMPTION identifier types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ====CONSUMPTION DEPENDENCY.======================================================== -->
-	<xsd:simpleType name="ConsumptionDependencyIdType">
+	<!-- ====ELEMENT CONSUMPTION POLICY.======================================================== -->
+	<xsd:simpleType name="ElementConsumptionPolicyIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a CONSUMPTION UTILISATION DEPENENCY.</xsd:documentation>
 		</xsd:annotation>
@@ -78,10 +78,10 @@
 		</xsd:restriction>
 	</xsd:simpleType>
 
-	<!-- ====CONSUMPTION.======================================================== -->
-	<xsd:simpleType name="ConsumptionIdType">
+	<!-- ====ELEMENT CONSUMPTION======================================================== -->
+	<xsd:simpleType name="ElementConsumptionIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
@@ -95,7 +95,7 @@
 	</xsd:simpleType>
 
 	<!-- ====CONSUMPTION TRANSITION POLICY.======================================================== -->
-	<xsd:simpleType name="ConsumptionTransitionPolicyEnumeration">
+	<xsd:simpleType name="ConsumptionTriggerTypeEnumeration">
 		<xsd:annotation>
 			<xsd:documentation>Specifies whether the Consumptions must be triggered automatically or manually</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
@@ -27,26 +27,26 @@
 		</xsd:appinfo>
 		<xsd:documentation>NeTEx: CONSUMPTION identifier types.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ====CONSUMPTION UTILISATION DEPENDENCY.======================================================== -->
-	<xsd:simpleType name="ConsumptionUtilisationDependencyIdType">
+	<!-- ====CONSUMPTION DEPENDENCY.======================================================== -->
+	<xsd:simpleType name="ConsumptionDependencyIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a CONSUMPTION UTILISATION DEPENENCY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
 	
-	<!-- ====CONSUMPTION DEPENDENCY.======================================================== -->
-	<xsd:simpleType name="ConsumptionDependencyIdType">
+	<!-- ====CONSUMPTION REQUIREMENT.======================================================== -->
+	<xsd:simpleType name="ConsumptionRequirementIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a CONSUMPTION REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
 	
-	<!-- ====CONSUMPTION UTILISATION.======================================================== -->
-	<xsd:simpleType name="ConsumptionUtilisationIdType">
+	<!-- ====CONSUMPTION.======================================================== -->
+	<xsd:simpleType name="ConsumptionIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a CONSUMPTION UTILISATION.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_customerPurchasePackage_support">
+	<xsd:include schemaLocation="../part3_fares/netex_accessRightParameter_support.xsd"/>
+	<!-- =============================================================== -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.2 CEN TC278 WG3 SG9 Editor Arne Seime</Creator>
+				<Date>
+					<Created>2021-02-04</Created>
+				</Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the CONSUMPTION types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Title>NeTEx CONSUMPTION identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx: CONSUMPTION identifier types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ====CONSUMPTION UTILISATION DEPENDENCY.======================================================== -->
+	<xsd:simpleType name="ConsumptionUtilisationDependencyIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CONSUMPTION UTILISATION DEPENENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	
+	<!-- ====CONSUMPTION DEPENDENCY.======================================================== -->
+	<xsd:simpleType name="ConsumptionDependencyIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	
+	<!-- ====CONSUMPTION UTILISATION.======================================================== -->
+	<xsd:simpleType name="ConsumptionUtilisationIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CONSUMPTION UTILISATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	
+	<!-- ====CROSS CONSTRAINT.======================================================== -->
+	<xsd:simpleType name="CrossConstraintIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CROSS CONSTRAINT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+
+	<!-- ====CONSUMPTION TRANSITION POLICY.======================================================== -->
+	<xsd:simpleType name="ConsumptionTransitionPolicyEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Specifies whether the ConsumptionUtilisations must be triggered automatically or manually</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="manual"/>
+			<xsd:enumeration value="automatic"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<!-- ====MAXIMUM NUMBER OF ACCESSES.======================================================== -->
+	<xsd:simpleType name="MaximumNumberOfAccessesEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Specifies the type of </xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="limited">
+				<xsd:annotation>
+					<xsd:documentation>The number of accesses is limited by a value</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="unlimited">
+				<xsd:annotation>
+					<xsd:documentation>Unlimited number of accesses</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<!-- =============================================================== -->
+</xsd:schema>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
@@ -62,7 +62,7 @@
 	<!-- ====CONSUMPTION TRANSITION POLICY.======================================================== -->
 	<xsd:simpleType name="ConsumptionTransitionPolicyEnumeration">
 		<xsd:annotation>
-			<xsd:documentation>Specifies whether the ConsumptionUtilisations must be triggered automatically or manually</xsd:documentation>
+			<xsd:documentation>Specifies whether the Consumptions must be triggered automatically or manually</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:normalizedString">
 			<xsd:enumeration value="manual"/>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_support.xsd
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_customerPurchasePackage_support">
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_customerPurchasePackage_support">
 	<xsd:include schemaLocation="../part3_fares/netex_accessRightParameter_support.xsd"/>
 	<!-- =============================================================== -->
 	<xsd:annotation>
@@ -34,7 +35,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	
+
 	<!-- ====CONSUMPTION REQUIREMENT.======================================================== -->
 	<xsd:simpleType name="ConsumptionRequirementIdType">
 		<xsd:annotation>
@@ -42,7 +43,41 @@
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	
+
+	<!-- ====MARKED AS TEMPORAL VALIDITY.======================================================== -->
+	<xsd:simpleType name="MarkedAsTemporalValidityEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Specifies the temporal aspects of a CONSUMPTION REQUIREMENT</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:normalizedString">
+			<xsd:enumeration value="any">
+				<xsd:annotation>
+					<xsd:documentation>Any ElementAccess with correct markedAs will fulfill requirement, regardless of validity period</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="current">
+				<xsd:annotation>
+					<xsd:documentation>A currently active ElementAccess with correct markedAs is required to fulfill requirement</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="future">
+				<xsd:annotation>
+					<xsd:documentation>A not yet active ElementAccess with correct markedAs is required to fulfill requirement</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="currentFuture">
+				<xsd:annotation>
+					<xsd:documentation>A currently or not yet active ElementAccess with correct markedAs is required to fulfill requirement</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="expired">
+				<xsd:annotation>
+					<xsd:documentation>An expired ElementAccess with correct markedAs is required to fulfill requirement</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
 	<!-- ====CONSUMPTION.======================================================== -->
 	<xsd:simpleType name="ConsumptionIdType">
 		<xsd:annotation>
@@ -50,7 +85,7 @@
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	
+
 	<!-- ====CROSS CONSTRAINT.======================================================== -->
 	<xsd:simpleType name="CrossConstraintIdType">
 		<xsd:annotation>
@@ -69,7 +104,7 @@
 			<xsd:enumeration value="automatic"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<!-- ====MAXIMUM NUMBER OF ACCESSES.======================================================== -->
 	<xsd:simpleType name="MaximumNumberOfAccessesEnumeration">
 		<xsd:annotation>
@@ -88,6 +123,6 @@
 			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
-	
+
 	<!-- =============================================================== -->
 </xsd:schema>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -228,12 +228,12 @@
 			<xsd:documentation>Elements for CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="FromMarkedAs" type="MarkedAsEnumeration" minOccurs="0">
+			<xsd:element name="FromMarkedAs" type="MarkedAsEnumeration" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Specifies the expected state of the ElementAccess before execution</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ToMarkedAs" type="MarkedAsEnumeration" minOccurs="0">
+			<xsd:element name="ToMarkedAs" type="MarkedAsEnumeration" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Specifies the expected state of the ElementAccess after execution</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -228,12 +228,12 @@
 			<xsd:documentation>Elements for CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="FromMarkedAs" type="MarkedAsEnumeration" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="FromMarkedAs" type="MarkedAsEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Specifies the expected state of the ElementAccess before execution</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ToMarkedAs" type="MarkedAsEnumeration" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="ToMarkedAs" type="MarkedAsEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Specifies the expected state of the ElementAccess after execution</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -33,131 +33,30 @@
 		<xsd:documentation>NeTEx: CONSUMPTION types.</xsd:documentation>
 	</xsd:annotation>
 	
-	<!-- ====CONSUMPTION UTILISATION DEPENDENCIES================================================= -->
-	<xsd:complexType name="consumptionUtilisationDependencies_RelStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a list of CONSUMPTION UTILISATION DEPENDENCIESs.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="strictContainmentAggregationStructure">
-				<xsd:sequence>
-					<xsd:element ref="ConsumptionUtilisationDependency" maxOccurs="unbounded"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:element name="ConsumptionUtilisationDependency" abstract="false">
-		<xsd:annotation>
-			<xsd:documentation>The definition of a CONSUMPTION UTILISATION DEPENDENCY accross multiple CUSTOMER PURCHASE PACKAGE ELEMENTs</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:restriction base="ConsumptionUtilisationDependency_VersionedChildStructure">
-					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="VersionedChildGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="ConsumptionUtilisationDependencyGroup"/>
-						</xsd:sequence>
-					</xsd:sequence>
-					<xsd:attribute name="id" type="ConsumptionUtilisationDependencyIdType"/>
-				</xsd:restriction>
-			</xsd:complexContent>
-		</xsd:complexType>
-	</xsd:element>
-	<xsd:complexType name="ConsumptionUtilisationDependency_VersionedChildStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION UTILISATION DEPENDENCY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="VersionedChildStructure">
-				<xsd:sequence>
-					<xsd:group ref="ConsumptionUtilisationDependencyGroup"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:group name="ConsumptionUtilisationDependencyGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for CONSUMPTION UTILISATION DEPENDENCY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
-			<xsd:element name="ConsumptionDependencyGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
-			<xsd:element name="consumptionDependencies" type="consumptionDependencies_RelStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>CONSUMPTION DEPENDENCY elements.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="ConsumptionTransitionPolicy" type="ConsumptionTransitionPolicyEnumeration"/>
-			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
-			<xsd:element name="ConsumptionUtilisationGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
-			<xsd:element name="consumptionUtilisations" type="consumptionUtilisations_RelStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>CONSUMPTION UTILISATION elements.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element name="crossConstraints" type="crossConstraints_RelStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>CROSS CONSTRAINTS elements.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-			<xsd:element ref="MaximumNumberOfAccesses" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Overall maximum number of acceses for the consumption utilisation elements</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:group>
+	<!-- ====CONSUMPTION DEPENDENCIES================================================= -->
 	<xsd:complexType name="consumptionDependencies_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of CONSUMPTION DEPENDENCIES.</xsd:documentation>
+			<xsd:documentation>Type for a list of CONSUMPTION DEPENDENCIESs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="ConsumptionDependency_" maxOccurs="unbounded"/>
+					<xsd:element ref="ConsumptionDependency" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:complexType name="consumptionUtilisations_RelStructure">
+	<xsd:element name="ConsumptionDependency" abstract="false">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of CONSUMPTION UTILISATIONS.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="containmentAggregationStructure">
-				<xsd:sequence>
-					<xsd:element ref="ConsumptionUtilisation_" maxOccurs="unbounded"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:complexType name="crossConstraints_RelStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a list of CROSS CONSTRAINTS.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="containmentAggregationStructure">
-				<xsd:sequence>
-					<xsd:element ref="CrossConstraint" maxOccurs="unbounded"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	
-	
-	<!-- === CONSUMPTION DEPENDENCY =========================================== -->
-	<xsd:element name="ConsumptionDependency_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
-	<xsd:element name="ConsumptionDependency" abstract="true" substitutionGroup="ConsumptionDependency_">
-		<xsd:annotation>
-			<xsd:documentation>The CONSUMPTION DEPENDENCY defines which state a CUSTOMER PURCHASE PACKAGE ELEMENT must be in (recorded via ElementAccesses)</xsd:documentation>
+			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY accross multiple CUSTOMER PURCHASE PACKAGE ELEMENTs</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:restriction base="ConsumptionDependency_VersionedChildStructure">
 					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="ConsumptionDependencyGroup"/>
 						</xsd:sequence>
@@ -184,33 +83,134 @@
 			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
+			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
+			<xsd:element name="ConsumptionRequirementGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
+			<xsd:element name="consumptionRequirements" type="consumptionRequirements_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CONSUMPTION DEPENDENCY elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ConsumptionTransitionPolicy" type="ConsumptionTransitionPolicyEnumeration"/>
+			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
+			<xsd:element name="ConsumptionGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
+			<xsd:element name="consumptions" type="consumptions_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CONSUMPTION elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="crossConstraints" type="crossConstraints_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CROSS CONSTRAINTS elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="MaximumNumberOfAccesses" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Overall maximum number of acceses for the consumption utilisation elements</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="consumptionRequirements_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CONSUMPTION REQUIREMENTS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="ConsumptionRequirement_" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="consumptions_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CONSUMPTIONs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="Consumption_" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="crossConstraints_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CROSS CONSTRAINTS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="CrossConstraint" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	
+	<!-- === CONSUMPTION REQUIREMENT =========================================== -->
+	<xsd:element name="ConsumptionRequirement_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
+	<xsd:element name="ConsumptionRequirement" abstract="true" substitutionGroup="ConsumptionRequirement_">
+		<xsd:annotation>
+			<xsd:documentation>The CONSUMPTION REQUIREMENT defines which state a CUSTOMER PURCHASE PACKAGE ELEMENT must be in (recorded via ElementAccesses)</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="ConsumptionRequirement_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ConsumptionRequirementGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ConsumptionRequirementIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="ConsumptionRequirement_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION REQUIREMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="ConsumptionRequirementGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ConsumptionRequirementGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION REQUIREMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
 			<xsd:element name="MarkedAs" type="MarkedAsEnumeration"/>
 		</xsd:sequence>
 	</xsd:group>
 
 	
-	<!-- === CONSUMPTION UTILISATION =========================================== -->
-	<xsd:element name="ConsumptionUtilisation_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
-	<xsd:element name="ConsumptionUtilisation" abstract="true" substitutionGroup="ConsumptionUtilisation_">
+	<!-- === CONSUMPTION =========================================== -->
+	<xsd:element name="Consumption_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
+	<xsd:element name="Consumption" abstract="true" substitutionGroup="Consumption_">
 		<xsd:annotation>
-			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which ELEMENT that is to be processed</xsd:documentation>
+			<xsd:documentation>The definition of a CONSUMPTION defining which ELEMENT that is to be processed</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="ConsumptionUtilisation_VersionedChildStructure">
+				<xsd:restriction base="Consumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="VersionedChildGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="ConsumptionUtilisationIdType"/>
+					<xsd:attribute name="id" type="ConsumptionIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ConsumptionUtilisation_VersionedChildStructure">
+	<xsd:complexType name="Consumption_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION UTILISATION.</xsd:documentation>
+			<xsd:documentation>Type for CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="VersionedChildStructure">

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by Nicholas Knowles Knowles (Kizoom Ltd) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_customerPurchasePackage_version">
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="../../netex_framework/netex_responsibility/netex_responsibility_version.xsd"/>
+	<xsd:include schemaLocation="../../netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_part_3/part3_fares/netex_usageParameterEntitlement_version.xsd"/>
+	<xsd:include schemaLocation="netex_consumption_support.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.2 CEN TC278 WG3 SG9 Editor Arne Seime</Creator>
+				<Date>
+					<Created>2021-02-04</Created>
+				</Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the CONSUMPTION types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Title>NeTEx CONSUMPTION identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx: CONSUMPTION types.</xsd:documentation>
+	</xsd:annotation>
+	
+	<!-- ====CONSUMPTION UTILISATION DEPENDENCIES================================================= -->
+	<xsd:complexType name="consumptionUtilisationDependencies_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CONSUMPTION UTILISATION DEPENDENCIESs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="ConsumptionUtilisationDependency" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="ConsumptionUtilisationDependency" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CONSUMPTION UTILISATION DEPENDENCY accross multiple CUSTOMER PURCHASE PACKAGE ELEMENTs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="ConsumptionUtilisationDependency_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ConsumptionUtilisationDependencyGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ConsumptionUtilisationDependencyIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="ConsumptionUtilisationDependency_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION UTILISATION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="ConsumptionUtilisationDependencyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ConsumptionUtilisationDependencyGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION UTILISATION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
+			<xsd:element name="ConsumptionDependencyGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
+			<xsd:element name="consumptionDependencies" type="consumptionDependencies_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CONSUMPTION DEPENDENCY elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ConsumptionTransitionPolicy" type="ConsumptionTransitionPolicyEnumeration"/>
+			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
+			<xsd:element name="ConsumptionUtilisationGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
+			<xsd:element name="consumptionUtilisations" type="consumptionUtilisations_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CONSUMPTION UTILISATION elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="crossConstraints" type="crossConstraints_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CROSS CONSTRAINTS elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="MaximumNumberOfAccesses" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Overall maximum number of acceses for the consumption utilisation elements</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="consumptionDependencies_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CONSUMPTION DEPENDENCIES.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="ConsumptionDependency_" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="consumptionUtilisations_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CONSUMPTION UTILISATIONS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="ConsumptionUtilisation_" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="crossConstraints_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CROSS CONSTRAINTS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="CrossConstraint" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	
+	<!-- === CONSUMPTION DEPENDENCY =========================================== -->
+	<xsd:element name="ConsumptionDependency_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
+	<xsd:element name="ConsumptionDependency" abstract="true" substitutionGroup="ConsumptionDependency_">
+		<xsd:annotation>
+			<xsd:documentation>The CONSUMPTION DEPENDENCY defines which state a CUSTOMER PURCHASE PACKAGE ELEMENT must be in (recorded via ElementAccesses)</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="ConsumptionDependency_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ConsumptionDependencyGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ConsumptionDependencyIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="ConsumptionDependency_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="ConsumptionDependencyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ConsumptionDependencyGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="MarkedAs" type="MarkedAsEnumeration"/>
+		</xsd:sequence>
+	</xsd:group>
+
+	
+	<!-- === CONSUMPTION UTILISATION =========================================== -->
+	<xsd:element name="ConsumptionUtilisation_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
+	<xsd:element name="ConsumptionUtilisation" abstract="true" substitutionGroup="ConsumptionUtilisation_">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which ELEMENT that is to be processed</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="ConsumptionUtilisation_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ConsumptionUtilisationIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="ConsumptionUtilisation_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION UTILISATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+	<!-- === CROSS CONSTRAINT =========================================== -->
+	<xsd:element name="CrossConstraint" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CROSS CONSTRAINTS defining constraints for parameter selection</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="CrossConstraint_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CrossConstraintGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CrossConstraintIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="CrossConstraint_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION UTILISATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="CrossConstraintGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CrossConstraintGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION UTILISATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Constraint" type="EntitlementConstraintStructure"/>
+			<xsd:element name="validityParameterAssignments" type="validityParameterAssignmentRefs_RelStructure"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ====MAXIMUM NUMBER OF ACCESSES.======================================================== -->
+	<xsd:element name="MaximumNumberOfAccesses">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="Type" type="MaximumNumberOfAccessesEnumeration"/>
+				<xsd:element name="Value" type="xsd:positiveInteger" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>If type is limited, specify value</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -33,67 +33,67 @@
 		<xsd:documentation>NeTEx: CONSUMPTION types.</xsd:documentation>
 	</xsd:annotation>
 	
-	<!-- ====CONSUMPTION DEPENDENCIES================================================= -->
-	<xsd:complexType name="consumptionDependencies_RelStructure">
+	<!-- ====ELEMENT CONSUMPTION POLICES================================================= -->
+	<xsd:complexType name="elementConsumptionPolicies_RelStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for a list of CONSUMPTION DEPENDENCIESs.</xsd:documentation>
+			<xsd:documentation>Type for a list of ELEMENT CONSUMPTION POLICESs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="strictContainmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="ConsumptionDependency" maxOccurs="unbounded"/>
+					<xsd:element ref="ElementConsumptionPolicy" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:element name="ConsumptionDependency" abstract="false">
+	<xsd:element name="ElementConsumptionPolicy" abstract="false">
 		<xsd:annotation>
-			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY accross multiple CUSTOMER PURCHASE PACKAGE ELEMENTs</xsd:documentation>
+			<xsd:documentation>The definition of a ELEMENT CONSUMPTION POLICY accross multiple CUSTOMER PURCHASE PACKAGE ELEMENTs</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="ConsumptionDependency_VersionedChildStructure">
+				<xsd:restriction base="ElementConsumptionPolicy_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="VersionedChildGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="ConsumptionDependencyGroup"/>
+							<xsd:group ref="ElementConsumptionPolicyGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="ConsumptionDependencyIdType"/>
+					<xsd:attribute name="id" type="ElementConsumptionPolicyIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="ConsumptionDependency_VersionedChildStructure">
+	<xsd:complexType name="ElementConsumptionPolicy_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="VersionedChildStructure">
 				<xsd:sequence>
-					<xsd:group ref="ConsumptionDependencyGroup"/>
+					<xsd:group ref="ElementConsumptionPolicyGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="ConsumptionDependencyGroup">
+	<xsd:group name="ElementConsumptionPolicyGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Elements for ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
 			<xsd:element name="ConsumptionRequirementGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
 			<xsd:element name="consumptionRequirements" type="consumptionRequirements_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>CONSUMPTION DEPENDENCY elements.</xsd:documentation>
+					<xsd:documentation>ELEMENT CONSUMPTION POLICY elements.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="ConsumptionTransitionPolicy" type="ConsumptionTransitionPolicyEnumeration"/>
+			<xsd:element name="ConsumptionTriggerType" type="ConsumptionTriggerTypeEnumeration"/>
 			<!-- TODO must be replaced with LogicalOperatorEnumeration when https://github.com/NeTEx-CEN/NeTEx/pull/126 is merged -->
-			<xsd:element name="ConsumptionGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
-			<xsd:element name="consumptions" type="consumptions_RelStructure" minOccurs="0">
+			<xsd:element name="ElementConsumptionGroupingType" type="BooleanOperatorEnumeration" minOccurs="0" default="AND"/>
+			<xsd:element name="elementConsumptions" type="elementConsumptions_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>CONSUMPTION elements.</xsd:documentation>
 				</xsd:annotation>
@@ -122,14 +122,14 @@
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:complexType name="consumptions_RelStructure">
+	<xsd:complexType name="elementConsumptions_RelStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for a list of CONSUMPTIONs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="Consumption_" maxOccurs="unbounded"/>
+					<xsd:element ref="ElementConsumption_" maxOccurs="unbounded"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -191,41 +191,41 @@
 
 	
 	<!-- === CONSUMPTION =========================================== -->
-	<xsd:element name="Consumption_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
-	<xsd:element name="Consumption" abstract="true" substitutionGroup="Consumption_">
+	<xsd:element name="ElementConsumption_" type="VersionedChildStructure" substitutionGroup="VersionedChild" abstract="true"/>
+	<xsd:element name="ElementConsumption" abstract="true" substitutionGroup="ElementConsumption_">
 		<xsd:annotation>
 			<xsd:documentation>The definition of a CONSUMPTION defining which ELEMENT that is to be processed</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="Consumption_VersionedChildStructure">
+				<xsd:restriction base="ElementConsumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="VersionedChildGroup"/>
-							<xsd:group ref="ConsumptionGroup"/>
+							<xsd:group ref="ElementConsumptionGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="ConsumptionIdType"/>
+					<xsd:attribute name="id" type="ElementConsumptionIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="Consumption_VersionedChildStructure">
+	<xsd:complexType name="ElementConsumption_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Type for ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="VersionedChildStructure">
 				<xsd:sequence>
-					<xsd:group ref="ConsumptionGroup"/>
+					<xsd:group ref="ElementConsumptionGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:group name="ConsumptionGroup">
+	<xsd:group name="ElementConsumptionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Elements for ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="FromMarkedAs" type="MarkedAsEnumeration" minOccurs="0">

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -185,6 +185,7 @@
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="MarkedAs" type="MarkedAsEnumeration"/>
+			<xsd:element name="MarkedAsTemporalValidity" type="MarkedAsTemporalValidityEnumeration"/>
 		</xsd:sequence>
 	</xsd:group>
 
@@ -201,6 +202,7 @@
 					<xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="VersionedChildGroup"/>
+							<xsd:group ref="ConsumptionGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="ConsumptionIdType"/>
@@ -214,11 +216,31 @@
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="ConsumptionGroup"/>
+				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 
-
+	<xsd:group name="ConsumptionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FromMarkedAs" type="MarkedAsEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Specifies the expected state of the ElementAccess before execution</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ToMarkedAs" type="MarkedAsEnumeration" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Specifies the expected state of the ElementAccess after execution</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	
 	<!-- === CROSS CONSTRAINT =========================================== -->
 	<xsd:element name="CrossConstraint" abstract="false">
 		<xsd:annotation>
@@ -228,9 +250,7 @@
 			<xsd:complexContent>
 				<xsd:restriction base="CrossConstraint_VersionedChildStructure">
 					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="CrossConstraintGroup"/>
-						</xsd:sequence>
+						<xsd:group ref="CrossConstraintGroup"/>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="CrossConstraintIdType"/>
 				</xsd:restriction>

--- a/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
+++ b/xsd/netex_part_3/part3_consumption/netex_consumption_version.xsd
@@ -184,7 +184,7 @@
 			<xsd:documentation>Elements for CONSUMPTION REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="MarkedAs" type="MarkedAsEnumeration"/>
+			<xsd:element name="MarkedAs" type="MarkedAsEnumeration" maxOccurs="unbounded"/>
 			<xsd:element name="MarkedAsTemporalValidity" type="MarkedAsTemporalValidityEnumeration"/>
 		</xsd:sequence>
 	</xsd:group>

--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_support.xsd
@@ -128,6 +128,25 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	<xsd:element name="ValidityParameterAssignmentRef" type="ValidityParameterAssignmentRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a VALIDITY PARAMETER ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="validityParameterAssignmentRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>A collection of one or more VALIDITY PARAMETER ASSIGNMENTs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="ValidityParameterAssignmentRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	
 	<!-- === GENERIC PARAMETER====================================================== -->
 	<xsd:simpleType name="GenericParameterAssignmentIdType">
 		<xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
@@ -309,17 +309,17 @@ Rail transport, Roads and Road transport
 	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION REQUIREMENT.======================================================== -->
 	<xsd:simpleType name="AccessRightInProductConsumptionRequirementIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="ConsumptionDependencyIdType"/>
+		<xsd:restriction base="ElementConsumptionPolicyIdType"/>
 	</xsd:simpleType>
 	
-	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION.======================================================== -->
-	<xsd:simpleType name="AccessRightInProductConsumptionIdType">
+	<!-- ====ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION======================================================== -->
+	<xsd:simpleType name="AccessRightInProductElementConsumptionIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="ConsumptionIdType"/>
+		<xsd:restriction base="ElementConsumptionIdType"/>
 	</xsd:simpleType>
 	
 	<!-- =============================================================== -->

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
@@ -3,6 +3,7 @@
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_salesOfferPackage_support">
 	<xsd:include schemaLocation="netex_fareProduct_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_notice_support.xsd"/>
+	<xsd:include schemaLocation="../part3_consumption/netex_consumption_support.xsd"/>
 	<!-- =============================================================== -->
 	<xsd:annotation>
 		<xsd:appinfo>
@@ -305,5 +306,21 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.======================================================== -->
+	<xsd:simpleType name="AccessRightInProductConsumptionDependencyIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ConsumptionDependencyIdType"/>
+	</xsd:simpleType>
+	
+	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION.======================================================== -->
+	<xsd:simpleType name="AccessRightInProductConsumptionUtilisationIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ConsumptionUtilisationIdType"/>
+	</xsd:simpleType>
+	
 	<!-- =============================================================== -->
 </xsd:schema>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_support.xsd
@@ -306,20 +306,20 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.======================================================== -->
-	<xsd:simpleType name="AccessRightInProductConsumptionDependencyIdType">
+	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION REQUIREMENT.======================================================== -->
+	<xsd:simpleType name="AccessRightInProductConsumptionRequirementIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="ConsumptionDependencyIdType"/>
 	</xsd:simpleType>
 	
-	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION.======================================================== -->
-	<xsd:simpleType name="AccessRightInProductConsumptionUtilisationIdType">
+	<!-- ====ACCESS RIGHT IN PRODUCT CONSUMPTION.======================================================== -->
+	<xsd:simpleType name="AccessRightInProductConsumptionIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a ACCESS RIGHT IN PRODUCT CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="ConsumptionUtilisationIdType"/>
+		<xsd:restriction base="ConsumptionIdType"/>
 	</xsd:simpleType>
 	
 	<!-- =============================================================== -->

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -249,7 +249,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="distributionAssignments" type="distributionAssignments_RelStructure" minOccurs="0"/>
 			<xsd:group ref="SalesOfferPackagePricingGroup"/>
-			<xsd:element name="consumptionUtilisationDependencies" type="consumptionUtilisationDependencies_RelStructure" minOccurs="0">
+			<xsd:element name="consumptionDependencies" type="consumptionDependencies_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>CONSUMPTION UTLIISATION DEPENDENCIES in SALES OFFER PACKAGE.</xsd:documentation>
 				</xsd:annotation>
@@ -839,42 +839,42 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ==== ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY ======= -->
-	<xsd:element name="AccessRightInProductConsumptionDependency" substitutionGroup="ConsumptionDependency_">
+	<xsd:element name="AccessRightInProductConsumptionRequirement" substitutionGroup="ConsumptionRequirement_">
 		<xsd:annotation>
 			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY defining which state a ACCESS RIGHT IN PRODUCT must be in (recorded via CustomerPurchasePackageElementAccesses)</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="AccessRightInProductConsumptionDependency_VersionedChildStructure">
+				<xsd:restriction base="AccessRightInProductConsumptionRequirement_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="VersionedChildGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="ConsumptionDependencyGroup"/>
+							<xsd:group ref="ConsumptionRequirementGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="AccessRightInProductConsumptionDependencyGroup"/>
+							<xsd:group ref="AccessRightInProductConsumptionRequirementGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="AccessRightInProductConsumptionDependencyIdType"/>
+					<xsd:attribute name="id" type="AccessRightInProductConsumptionRequirementIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element> 
-	<xsd:complexType name="AccessRightInProductConsumptionDependency_VersionedChildStructure">
+	<xsd:complexType name="AccessRightInProductConsumptionRequirement_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="ConsumptionDependency_VersionedChildStructure">
+			<xsd:extension base="ConsumptionRequirement_VersionedChildStructure">
 				<xsd:sequence>
-					<xsd:group ref="AccessRightInProductConsumptionDependencyGroup"/>
+					<xsd:group ref="AccessRightInProductConsumptionRequirementGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="AccessRightInProductConsumptionDependencyGroup">
+	<xsd:group name="AccessRightInProductConsumptionRequirementGroup">
 		<xsd:annotation>
 			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
 		</xsd:annotation>
@@ -888,39 +888,39 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION ======= -->
-	<xsd:element name="AccessRightInProductConsumptionUtilisation" abstract="false" substitutionGroup="ConsumptionUtilisation_">
+	<xsd:element name="AccessRightInProductConsumption" abstract="false" substitutionGroup="Consumption_">
 		<xsd:annotation>
 			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which ACCESS RIGHT IN PRODUCT that is to be processed</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="AccessRightInProductConsumptionUtilisation_VersionedChildStructure">
+				<xsd:restriction base="AccessRightInProductConsumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
 							<xsd:group ref="VersionedChildGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="AccessRightInProductConsumptionUtilisationGroup"/>
+							<xsd:group ref="AccessRightInProductConsumptionGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="AccessRightInProductConsumptionUtilisationIdType"/>
+					<xsd:attribute name="id" type="AccessRightInProductConsumptionIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="AccessRightInProductConsumptionUtilisation_VersionedChildStructure">
+	<xsd:complexType name="AccessRightInProductConsumption_VersionedChildStructure">
 		<xsd:annotation>
 			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="ConsumptionUtilisation_VersionedChildStructure">
+			<xsd:extension base="Consumption_VersionedChildStructure">
 				<xsd:sequence>
-					<xsd:group ref="AccessRightInProductConsumptionUtilisationGroup"/>
+					<xsd:group ref="AccessRightInProductConsumptionGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="AccessRightInProductConsumptionUtilisationGroup">
+	<xsd:group name="AccessRightInProductConsumptionGroup">
 		<xsd:annotation>
 			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
 		</xsd:annotation>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -896,12 +896,9 @@ Rail transport, Roads and Road transport
 			<xsd:complexContent>
 				<xsd:restriction base="AccessRightInProductConsumption_VersionedChildStructure">
 					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="VersionedChildGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="AccessRightInProductConsumptionGroup"/>
-						</xsd:sequence>
+						<xsd:group ref="VersionedChildGroup"/>
+						<xsd:group ref="ConsumptionGroup"/>
+						<xsd:group ref="AccessRightInProductConsumptionGroup"/>
 					</xsd:sequence>
 					<xsd:attribute name="id" type="AccessRightInProductConsumptionIdType"/>
 				</xsd:restriction>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -249,7 +249,7 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="distributionAssignments" type="distributionAssignments_RelStructure" minOccurs="0"/>
 			<xsd:group ref="SalesOfferPackagePricingGroup"/>
-			<xsd:element name="consumptionDependencies" type="consumptionDependencies_RelStructure" minOccurs="0">
+			<xsd:element name="elementConsumptionPolicies" type="elementConsumptionPolicies_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>CONSUMPTION UTLIISATION DEPENDENCIES in SALES OFFER PACKAGE.</xsd:documentation>
 				</xsd:annotation>
@@ -838,10 +838,10 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="TypeOfEntity_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<!-- ==== ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY ======= -->
+	<!-- ==== ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION POLICY ======= -->
 	<xsd:element name="AccessRightInProductConsumptionRequirement" substitutionGroup="ConsumptionRequirement_">
 		<xsd:annotation>
-			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY defining which state a ACCESS RIGHT IN PRODUCT must be in (recorded via CustomerPurchasePackageElementAccesses)</xsd:documentation>
+			<xsd:documentation>The definition of a ELEMENT CONSUMPTION POLICY defining which state a ACCESS RIGHT IN PRODUCT must be in (recorded via CustomerPurchasePackageElementAccesses)</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
@@ -864,7 +864,7 @@ Rail transport, Roads and Road transport
 	</xsd:element> 
 	<xsd:complexType name="AccessRightInProductConsumptionRequirement_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="ConsumptionRequirement_VersionedChildStructure">
@@ -876,7 +876,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="AccessRightInProductConsumptionRequirementGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="AccessRightInProductRef"/>
@@ -888,7 +888,7 @@ Rail transport, Roads and Road transport
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ==== ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION ======= -->
-	<xsd:element name="AccessRightInProductConsumption" abstract="false" substitutionGroup="Consumption_">
+	<xsd:element name="AccessRightInProductConsumption" abstract="false" substitutionGroup="ElementConsumption_">
 		<xsd:annotation>
 			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which ACCESS RIGHT IN PRODUCT that is to be processed</xsd:documentation>
 		</xsd:annotation>
@@ -897,20 +897,20 @@ Rail transport, Roads and Road transport
 				<xsd:restriction base="AccessRightInProductConsumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:group ref="VersionedChildGroup"/>
-						<xsd:group ref="ConsumptionGroup"/>
+						<xsd:group ref="ElementConsumptionGroup"/>
 						<xsd:group ref="AccessRightInProductConsumptionGroup"/>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="AccessRightInProductConsumptionIdType"/>
+					<xsd:attribute name="id" type="AccessRightInProductElementConsumptionIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
 	<xsd:complexType name="AccessRightInProductConsumption_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="Consumption_VersionedChildStructure">
+			<xsd:extension base="ElementConsumption_VersionedChildStructure">
 				<xsd:sequence>
 					<xsd:group ref="AccessRightInProductConsumptionGroup"/>
 				</xsd:sequence>
@@ -919,7 +919,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="AccessRightInProductConsumptionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT ELEMENT CONSUMPTION POLICY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="AccessRightInProductRef"/>

--- a/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_salesOfferPackage_version.xsd
@@ -3,6 +3,7 @@
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_salesOfferPackage_version">
 	<xsd:include schemaLocation="netex_salesOfferPackage_support.xsd"/>
 	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_topographicPlace_support.xsd"/>
+	<xsd:include schemaLocation="../part3_consumption/netex_consumption_version.xsd"/>
 	<!-- ======================================================================= -->
 	<xsd:include schemaLocation="netex_salesDistribution_version.xsd"/>
 	<xsd:include schemaLocation="netex_fareProduct_version.xsd"/>
@@ -248,6 +249,11 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 			<xsd:element name="distributionAssignments" type="distributionAssignments_RelStructure" minOccurs="0"/>
 			<xsd:group ref="SalesOfferPackagePricingGroup"/>
+			<xsd:element name="consumptionUtilisationDependencies" type="consumptionUtilisationDependencies_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CONSUMPTION UTLIISATION DEPENDENCIES in SALES OFFER PACKAGE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="salesOfferPackageElements" type="salesOfferPackageElements_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>SALES OFFER PACKAGE ELEMENTs in SALES OFFER PACKAGE.</xsd:documentation>
@@ -832,4 +838,100 @@ Rail transport, Roads and Road transport
 			<xsd:extension base="TypeOfEntity_VersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
+	<!-- ==== ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY ======= -->
+	<xsd:element name="AccessRightInProductConsumptionDependency" substitutionGroup="ConsumptionDependency_">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY defining which state a ACCESS RIGHT IN PRODUCT must be in (recorded via CustomerPurchasePackageElementAccesses)</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="AccessRightInProductConsumptionDependency_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ConsumptionDependencyGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AccessRightInProductConsumptionDependencyGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="AccessRightInProductConsumptionDependencyIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element> 
+	<xsd:complexType name="AccessRightInProductConsumptionDependency_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ConsumptionDependency_VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="AccessRightInProductConsumptionDependencyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="AccessRightInProductConsumptionDependencyGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="AccessRightInProductRef"/>
+			<xsd:element name="AccessNumber" type="xsd:integer" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Number of access of this specific instance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== ACCESS RIGHT IN PRODUCT CONSUMPTION UTILISATION ======= -->
+	<xsd:element name="AccessRightInProductConsumptionUtilisation" abstract="false" substitutionGroup="ConsumptionUtilisation_">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which ACCESS RIGHT IN PRODUCT that is to be processed</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="AccessRightInProductConsumptionUtilisation_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AccessRightInProductConsumptionUtilisationGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="AccessRightInProductConsumptionUtilisationIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="AccessRightInProductConsumptionUtilisation_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ConsumptionUtilisation_VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="AccessRightInProductConsumptionUtilisationGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="AccessRightInProductConsumptionUtilisationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for ACCESS RIGHT IN PRODUCT CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="AccessRightInProductRef"/>
+			<xsd:element name="AccessNumber" type="xsd:integer" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Number of access of this specific instance.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	
 </xsd:schema>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterTravel_support.xsd
@@ -395,6 +395,11 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="profileExpiry"/>
 			<xsd:enumeration value="deregistration"/>
 			<xsd:enumeration value="other"/>
+			<xsd:enumeration value="noTemporalValidity">
+				<xsd:annotation>
+					<xsd:documentation>Indicate that there is no temporal validity to be added to ElementAccess when consuming</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="UsageStartConstraintTypeEnumeration">

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
@@ -440,11 +440,11 @@ Rail transport, Roads and Road transport
 		<xsd:restriction base="ConsumptionRequirementIdType"/>
 	</xsd:simpleType>
 	
-	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION.======================================================== -->
+	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT ELEMENT CONSUMPTION======================================================== -->
 	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="ConsumptionIdType"/>
+		<xsd:restriction base="ElementConsumptionIdType"/>
 	</xsd:simpleType>
 </xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="netex_customerPurchasePackage_support">
 	<xsd:include schemaLocation="../part3_fares/netex_accessRightParameter_support.xsd"/>
+	<xsd:include schemaLocation="../part3_consumption/netex_consumption_support.xsd"/>
 	<xsd:include schemaLocation="netex_salesContract_support.xsd"/>
 	<!-- =============================================================== -->
 	<xsd:annotation>
@@ -394,6 +395,21 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
+	
+	<!-- === GROUP OF CUSTOMER PURCHASE PACKAGE PARAMETER ASSIGNMENT====================================================== -->
+	<xsd:element name="CustomerPurchaseParameterAssignmentRef" type="CustomerPurchasePackageElementRefStructure" >
+		<xsd:annotation>
+			<xsd:documentation>Reference to a CUSTOMER PURCHASE PARAMETER ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:simpleType name="GroupOfCustomerPurchaseParameterAssignmentsIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a GROUP CUSTOMER PURCHASE PARAMETER ASSIGNMENTS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="GroupOfEntitiesIdType"/>
+	</xsd:simpleType>
+	
 	<!-- === CUSTOMER PURCHASE PACKAGE ELEMENT ACCESS. ====================================================== -->
 	<xsd:simpleType name="CustomerPurchasePackageElementAccessIdType">
 		<xsd:annotation>
@@ -415,5 +431,20 @@ Rail transport, Roads and Road transport
 			</xsd:restriction>
 		</xsd:simpleContent>
 	</xsd:complexType>
-	<!-- =============================================================== -->
+	
+	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION DEPENDENCY.======================================================== -->
+	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionDependencyIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ConsumptionDependencyIdType"/>
+	</xsd:simpleType>
+	
+	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION UTILISATION.======================================================== -->
+	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionUtilisationIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION UTILISATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ConsumptionUtilisationIdType"/>
+	</xsd:simpleType>
 </xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_support.xsd
@@ -432,19 +432,19 @@ Rail transport, Roads and Road transport
 		</xsd:simpleContent>
 	</xsd:complexType>
 	
-	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION DEPENDENCY.======================================================== -->
-	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionDependencyIdType">
+	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION REQUIREMENT.======================================================== -->
+	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionRequirementIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="ConsumptionDependencyIdType"/>
+		<xsd:restriction base="ConsumptionRequirementIdType"/>
 	</xsd:simpleType>
 	
-	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION UTILISATION.======================================================== -->
-	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionUtilisationIdType">
+	<!-- ====CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION.======================================================== -->
+	<xsd:simpleType name="CustomerPurchasePackageElementConsumptionIdType">
 		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION UTILISATION.</xsd:documentation>
+			<xsd:documentation>Type for identifier of a CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="ConsumptionUtilisationIdType"/>
+		<xsd:restriction base="ConsumptionIdType"/>
 	</xsd:simpleType>
 </xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -9,6 +9,7 @@
 	<xsd:include schemaLocation="netex_salesTransaction_support.xsd"/>
 	<xsd:include schemaLocation="../part3_fares/netex_validableElement_support.xsd"/>
 	<xsd:include schemaLocation="../part3_fares/netex_salesOfferPackage_version.xsd"/>
+	<xsd:include schemaLocation="../part3_consumption/netex_consumption_version.xsd"/>
 	<xsd:include schemaLocation="netex_travelSpecificationSummary_version.xsd"/>
 	<xsd:include schemaLocation="netex_salesContract_version.xsd"/>
 	<xsd:include schemaLocation="netex_travelSpecificationSummary_version.xsd"/>
@@ -585,6 +586,11 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DiISTRIBUTION ASSIGNMENTS for  CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="consumptionUtilisationDependencies" type="consumptionUtilisationDependencies_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>CONSUMPTION UTLIISATION DEPENDENCIES in CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="customerPurchasePackageElements" type="customerPurchasePackageElements_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>CUSTOMER PURCHASE PACKAGE ELEMENTs in CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
@@ -690,6 +696,11 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="CustomerPurchasePackageRef" minOccurs="0"/>
 			<xsd:element ref="SalesOfferPackageElementRef" minOccurs="0"/>
 			<xsd:group ref="CustomerPurchasePackageValidationGroup"/>
+			<xsd:element name="groupsOfCustomerPurchaseParameterAssignments" type="groupsOfCustomerPurchaseParameterAssignments_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>GROUPS OF VALIDITY PARAMETER ASSIGNMENTs applying to CUSTOMER PURCHASE PACKAGE ELEMENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="validityParameterAssignments" type="customerPurchaseParameterAssignments_RelStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>VALIDITY PARAMETER ASSIGNMENTs applying to CUSTOMER PURCHASE PACKAGE ELEMENT..</xsd:documentation>
@@ -915,6 +926,165 @@ Rail transport, Roads and Road transport
 		<xsd:annotation>
 			<xsd:documentation>Elements for a CUSTOMER PURCHASE PARAMETER ASSIGNMENT.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:sequence/>
+		<xsd:sequence>
+			<xsd:element ref="MaximumNumberOfAccesses" minOccurs="0"/>
+		</xsd:sequence>
 	</xsd:group>
+	
+	<!-- ==GROUP OF CUSTOMER PURCHASE PARAMETER ASSIGNMENTS ============================================================ -->
+	<xsd:complexType name="groupsOfCustomerPurchaseParameterAssignments_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment of GroupsOfCustomerPurchaseParameterAssignments.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="GroupOfCustomerPurchaseParameterAssignments" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="GroupOfCustomerPurchaseParameterAssignments" abstract="false" substitutionGroup="GroupOfEntities">
+		<xsd:annotation>
+			<xsd:documentation>A grouping of CUSTOMER PURCHASE PARAMETER ASSIGNMENTs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="GroupOfCustomerPurchaseParameterAssignments_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfEntitiesGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="GroupOfCustomerPurchaseParameterAssignmentsGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="GroupOfCustomerPurchaseParameterAssignmentsIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="GroupOfCustomerPurchaseParameterAssignments_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CUSTOMER PURCHASE PARAMETER ASSIGNMENTs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="GroupOfEntities_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="GroupOfCustomerPurchaseParameterAssignmentsGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="GroupOfCustomerPurchaseParameterAssignmentsGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CUSTOMER PURCHASE PARAMETER ASSIGNMENTs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="CustomerPurchaseParameterAssignmentRef" minOccurs="2" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:group>
+	
+	<xsd:complexType name="customerPurchaseParameterAssignmentRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CUSTOMER PURCHASE PARAMETER ASSIGNMENT REFs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="CustomerPurchaseParameterAssignmentRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION DEPENDENCY ======= -->
+	<xsd:element name="CustomerPurchasePackageElementConsumptionDependency" substitutionGroup="ConsumptionDependency_">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY defining which state a CUSTOMER PURCHASE PACKAGE ELEMENT must be in (recorded via ElementAccesses)</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="CustomerPurchasePackageElementConsumptionDependency_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ConsumptionDependencyGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerPurchasePackageElementConsumptionDependencyGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CustomerPurchasePackageElementConsumptionDependencyIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="CustomerPurchasePackageElementConsumptionDependency_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ConsumptionDependency_VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="CustomerPurchasePackageElementConsumptionDependencyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CustomerPurchasePackageElementConsumptionDependencyGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="CustomerPurchasePackageElementRef"/>
+		</xsd:sequence>
+	</xsd:group>
+	
+	
+
+	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION UTILISATION ======= -->
+	<xsd:element name="CustomerPurchasePackageElementConsumptionUtilisation" abstract="false" substitutionGroup="ConsumptionUtilisation_">
+		<xsd:annotation>
+			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which CUSTOMER PURCHASE PACKAGE ELEMENT that is to be processed</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="CustomerPurchasePackageElementConsumptionUtilisation_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CustomerPurchasePackageElementConsumptionUtilisationGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CustomerPurchasePackageElementConsumptionUtilisationIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="CustomerPurchasePackageElementConsumptionUtilisation_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ConsumptionUtilisation_VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:group ref="CustomerPurchasePackageElementConsumptionUtilisationGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CustomerPurchasePackageElementConsumptionUtilisationGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="CustomerPurchasePackageElementRef"/>
+		</xsd:sequence>
+	</xsd:group>
+	
 </xsd:schema>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -586,9 +586,9 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DiISTRIBUTION ASSIGNMENTS for  CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="consumptionDependencies" type="consumptionDependencies_RelStructure" minOccurs="0">
+			<xsd:element name="elementConsumptionPolicies" type="elementConsumptionPolicies_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>CONSUMPTION DEPENDENCIES in CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
+					<xsd:documentation>ELEMENT CONSUMPTION POLICES in CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="customerPurchasePackageElements" type="customerPurchasePackageElements_RelStructure" minOccurs="0">
@@ -1054,7 +1054,7 @@ Rail transport, Roads and Road transport
 	
 
 	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION ======= -->
-	<xsd:element name="CustomerPurchasePackageElementConsumption" abstract="false" substitutionGroup="Consumption_">
+	<xsd:element name="CustomerPurchasePackageElementConsumption" abstract="false" substitutionGroup="ElementConsumption_">
 		<xsd:annotation>
 			<xsd:documentation>The definition of a CONSUMPTION defining which CUSTOMER PURCHASE PACKAGE ELEMENT that is to be processed</xsd:documentation>
 		</xsd:annotation>
@@ -1063,7 +1063,7 @@ Rail transport, Roads and Road transport
 				<xsd:restriction base="CustomerPurchasePackageElementConsumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="ConsumptionGroup"/>
+							<xsd:group ref="ElementConsumptionGroup"/>
 							<xsd:group ref="CustomerPurchasePackageElementConsumptionGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
@@ -1074,10 +1074,10 @@ Rail transport, Roads and Road transport
 	</xsd:element>
 	<xsd:complexType name="CustomerPurchasePackageElementConsumption_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Type for ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="Consumption_VersionedChildStructure">
+			<xsd:extension base="ElementConsumption_VersionedChildStructure">
 				<xsd:sequence>
 					<xsd:group ref="CustomerPurchasePackageElementConsumptionGroup"/>
 				</xsd:sequence>
@@ -1086,7 +1086,7 @@ Rail transport, Roads and Road transport
 	</xsd:complexType>
 	<xsd:group name="CustomerPurchasePackageElementConsumptionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for CONSUMPTION.</xsd:documentation>
+			<xsd:documentation>Elements for ELEMENT CONSUMPTION</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="CustomerPurchasePackageElementRef"/>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -872,6 +872,11 @@ Rail transport, Roads and Road transport
 							<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters for a CUSTOMER PURCHASE PACKAGE, chosen from those available for a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
+					<xsd:element ref="CustomerPurchaseParameterAssignmentRef" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>A reference to an existing VALIDITY PARAMETER ASSIGNMENT specifying practical parameters for a CUSTOMER PURCHASE PACKAGE, chosen from those available for a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -867,12 +867,12 @@ Rail transport, Roads and Road transport
 		<xsd:complexContent>
 			<xsd:extension base="containmentAggregationStructure">
 				<xsd:sequence>
-					<xsd:element ref="CustomerPurchaseParameterAssignment" maxOccurs="unbounded">
+					<xsd:element ref="CustomerPurchaseParameterAssignment" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>A VALIDITY PARAMETER ASSIGNMENT specifying practical parameters for a CUSTOMER PURCHASE PACKAGE, chosen from those available for a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element ref="CustomerPurchaseParameterAssignmentRef" maxOccurs="unbounded">
+					<xsd:element ref="CustomerPurchaseParameterAssignmentRef" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
 							<xsd:documentation>A reference to an existing VALIDITY PARAMETER ASSIGNMENT specifying practical parameters for a CUSTOMER PURCHASE PACKAGE, chosen from those available for a given fare structure (e.g. the origin or destination zone in a zone-counting system).</xsd:documentation>
 						</xsd:annotation>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -1063,6 +1063,7 @@ Rail transport, Roads and Road transport
 				<xsd:restriction base="CustomerPurchasePackageElementConsumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
+							<xsd:group ref="ConsumptionGroup"/>
 							<xsd:group ref="CustomerPurchasePackageElementConsumptionGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_customerPurchasePackage_version.xsd
@@ -586,9 +586,9 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>DiISTRIBUTION ASSIGNMENTS for  CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="consumptionUtilisationDependencies" type="consumptionUtilisationDependencies_RelStructure" minOccurs="0">
+			<xsd:element name="consumptionDependencies" type="consumptionDependencies_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>CONSUMPTION UTLIISATION DEPENDENCIES in CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
+					<xsd:documentation>CONSUMPTION DEPENDENCIES in CUSTOMER PURCHASE PACKAGE.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="customerPurchasePackageElements" type="customerPurchasePackageElements_RelStructure" minOccurs="0">
@@ -1009,42 +1009,42 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION DEPENDENCY ======= -->
-	<xsd:element name="CustomerPurchasePackageElementConsumptionDependency" substitutionGroup="ConsumptionDependency_">
+	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION REQUIREMENT ======= -->
+	<xsd:element name="CustomerPurchasePackageElementConsumptionRequirement" substitutionGroup="ConsumptionRequirement_">
 		<xsd:annotation>
-			<xsd:documentation>The definition of a CONSUMPTION DEPENDENCY defining which state a CUSTOMER PURCHASE PACKAGE ELEMENT must be in (recorded via ElementAccesses)</xsd:documentation>
+			<xsd:documentation>The definition of a CONSUMPTION REQUIREMENT defining which state a CUSTOMER PURCHASE PACKAGE ELEMENT must be in (recorded via ElementAccesses)</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="CustomerPurchasePackageElementConsumptionDependency_VersionedChildStructure">
+				<xsd:restriction base="CustomerPurchasePackageElementConsumptionRequirement_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="ConsumptionDependencyGroup"/>
+							<xsd:group ref="ConsumptionRequirementGroup"/>
 						</xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="CustomerPurchasePackageElementConsumptionDependencyGroup"/>
+							<xsd:group ref="CustomerPurchasePackageElementConsumptionRequirementGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="CustomerPurchasePackageElementConsumptionDependencyIdType"/>
+					<xsd:attribute name="id" type="CustomerPurchasePackageElementConsumptionRequirementIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CustomerPurchasePackageElementConsumptionDependency_VersionedChildStructure">
+	<xsd:complexType name="CustomerPurchasePackageElementConsumptionRequirement_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for CONSUMPTION REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="ConsumptionDependency_VersionedChildStructure">
+			<xsd:extension base="ConsumptionRequirement_VersionedChildStructure">
 				<xsd:sequence>
-					<xsd:group ref="CustomerPurchasePackageElementConsumptionDependencyGroup"/>
+					<xsd:group ref="CustomerPurchasePackageElementConsumptionRequirementGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="CustomerPurchasePackageElementConsumptionDependencyGroup">
+	<xsd:group name="CustomerPurchasePackageElementConsumptionRequirementGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Elements for CONSUMPTION REQUIREMENT.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="CustomerPurchasePackageElementRef"/>
@@ -1053,39 +1053,39 @@ Rail transport, Roads and Road transport
 	
 	
 
-	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION UTILISATION ======= -->
-	<xsd:element name="CustomerPurchasePackageElementConsumptionUtilisation" abstract="false" substitutionGroup="ConsumptionUtilisation_">
+	<!-- ==== CUSTOMER PURCHASE PACKAGE ELEMENT CONSUMPTION ======= -->
+	<xsd:element name="CustomerPurchasePackageElementConsumption" abstract="false" substitutionGroup="Consumption_">
 		<xsd:annotation>
-			<xsd:documentation>The definition of a CONSUMPTION UTILISATION defining which CUSTOMER PURCHASE PACKAGE ELEMENT that is to be processed</xsd:documentation>
+			<xsd:documentation>The definition of a CONSUMPTION defining which CUSTOMER PURCHASE PACKAGE ELEMENT that is to be processed</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:restriction base="CustomerPurchasePackageElementConsumptionUtilisation_VersionedChildStructure">
+				<xsd:restriction base="CustomerPurchasePackageElementConsumption_VersionedChildStructure">
 					<xsd:sequence>
 						<xsd:sequence>
-							<xsd:group ref="CustomerPurchasePackageElementConsumptionUtilisationGroup"/>
+							<xsd:group ref="CustomerPurchasePackageElementConsumptionGroup"/>
 						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="CustomerPurchasePackageElementConsumptionUtilisationIdType"/>
+					<xsd:attribute name="id" type="CustomerPurchasePackageElementConsumptionIdType"/>
 				</xsd:restriction>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	<xsd:complexType name="CustomerPurchasePackageElementConsumptionUtilisation_VersionedChildStructure">
+	<xsd:complexType name="CustomerPurchasePackageElementConsumption_VersionedChildStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Type for CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="ConsumptionUtilisation_VersionedChildStructure">
+			<xsd:extension base="Consumption_VersionedChildStructure">
 				<xsd:sequence>
-					<xsd:group ref="CustomerPurchasePackageElementConsumptionUtilisationGroup"/>
+					<xsd:group ref="CustomerPurchasePackageElementConsumptionGroup"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	<xsd:group name="CustomerPurchasePackageElementConsumptionUtilisationGroup">
+	<xsd:group name="CustomerPurchasePackageElementConsumptionGroup">
 		<xsd:annotation>
-			<xsd:documentation>Elements for CONSUMPTION DEPENDENCY.</xsd:documentation>
+			<xsd:documentation>Elements for CONSUMPTION.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="CustomerPurchasePackageElementRef"/>


### PR DESCRIPTION
* Add support for usage interdependencies accross multiple SalesOfferPackageElements and corresponding CustomerPurchasePackageElements.
* Added MaximumNumberOfAccesses to signal usage count limitations instead of using  QualityStructureFactors for each possible number
* Added GroupOfCustomerPurchaseParameterAssignments to group different types of linked CustomerPurchaseParameterAssignments