### PR TITLE
Security level

### DIFF
--- a/examples/functions/fares/rail/Netex_era_distance_ro.xml
+++ b/examples/functions/fares/rail/Netex_era_distance_ro.xml
@@ -1080,6 +1080,14 @@ Tickets will be issued for the distance traveled by a single train and the conti
 							<MaxiumTimeAfterUse>PT24H</MaxiumTimeAfterUse> <!-- up to 24 hours after -->
 							<AllowedAfterControl>true</AllowedAfterControl> <!-- customer service can revert after control as well -->
 						</Reverting>
+						<SecurityPolicy version="any" id="tfc:TFC@Common@condition@accountSecurityLevel_highValueProduct">
+							<!-- A product with a long validity period requires a higher security level to reduce risk of fraud -->
+							<MinimumAccountSecurityLevel>-20</MinimumAccountSecurityLevel>
+						</SecurityPolicy>
+						<SecurityPolicy version="any" id="tfc:TFC@Common@condition@accountSecurityLevel_singleUseLocalTicket">
+							<!-- A product for single use on local travel can accept a lower security level    -->
+							<MinimumAccountSecurityLevel>-180</MinimumAccountSecurityLevel>
+						</SecurityPolicy>
 						<!---  ===OTHER USAGE PARAMETERS =========    -->
 					</usageParameters>
 					<!-- ====CHANNELS  -->

--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -7743,6 +7743,26 @@
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>
+		<!-- ===== SecurityPolicy Key ========================== -->
+		<!-- ===== SecurityPolicy unique========================== -->
+		<xsd:unique name="SecurityPolicy">
+			<xsd:annotation>
+				<xsd:documentation>Every [SecurityPolicy Id + Version] must be unique within document.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath=".//netex:SecurityPolicy"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:unique>
+		<xsd:keyref name="SecurityPolicy_KeyRef" refer="netex:SecurityPolicy_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SecurityPolicyRef"/>
+			<xsd:field xpath="@ref"/>
+			<xsd:field xpath="@version"/>
+		</xsd:keyref>
+		<xsd:key name="SecurityPolicy_AnyVersionedKey">
+			<xsd:selector xpath=".//netex:SecurityPolicy"/>
+			<xsd:field xpath="@id"/>
+			<xsd:field xpath="@version"/>
+		</xsd:key>
 		<!-- === EligibilityChangePolicy Key ========================== -->
 		<!-- =====EligibilityChangePolicy unique========================== -->
 		<xsd:unique name="EligibilityChangePolicy">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
@@ -278,12 +278,12 @@ Rail transport, Roads and Road transport
 	</xsd:simpleType>
 	<xsd:element name="SecurityPolicyRef" type="SecurityPolicyRefStructure" substitutionGroup="UsageParameterRef">
 		<xsd:annotation>
-			<xsd:documentation>Reference to a SECURITY POLICY usage parameter. +v1.1</xsd:documentation>
+			<xsd:documentation>Reference to a SECURITY POLICY usage parameter. </xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
 	<xsd:complexType name="SecurityPolicyRefStructure">
 		<xsd:annotation>
-			<xsd:documentation>Type for Reference to a SUBSCRIBING usage parameter.</xsd:documentation>
+			<xsd:documentation>Type for Reference to a SECURITY POLICY usage parameter.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
 			<xsd:restriction base="UsageParameterRefStructure">

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_support.xsd
@@ -269,5 +269,31 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>
+	<!-- ==== SECURITY POLICY USER PARAMETER ================================================ -->
+	<xsd:simpleType name="SecurityPolicyIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a SECURITY POLICY usage parameter.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="UsageParameterIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SecurityPolicyRef" type="SecurityPolicyRefStructure" substitutionGroup="UsageParameterRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SECURITY POLICY usage parameter. +v1.1</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SecurityPolicyRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a SUBSCRIBING usage parameter.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="UsageParameterRefStructure">
+				<xsd:attribute name="ref" type="SecurityPolicyIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SECURITY POLICY usage parameter.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
@@ -305,5 +305,59 @@ Rail transport, Roads and Road transport
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
+	<!-- ==== SECURITY POLICY USER PARAMETER ================================================ -->
+	<xsd:element name="SecurityPolicy" abstract="false" substitutionGroup="UsageParameter_">
+		<xsd:annotation>
+			<xsd:documentation>Policy regarding different aspects of security, for example required required security level for account based ticketing.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SecurityPolicy_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="PriceableObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="UsageParameterGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SecurityPolicyGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SecurityPolicyIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SecurityPolicy_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for SECURITY POLICY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="UsageParameter_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SecurityPolicyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SecurityPolicyGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for SECURITY POLICY Group.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SecurityLevel" type="xsd:nonPositiveInteger" >
+				<xsd:annotation>
+					<xsd:documentation>Required (minimum) sequrity level of any account that should hold a FareContract representing this product. The value is specified as a negative number, 0 is the highest level of security (most secure).  </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
 	<!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_usageParameterCharging_version.xsd
@@ -352,7 +352,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for SECURITY POLICY Group.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:element name="SecurityLevel" type="xsd:nonPositiveInteger" >
+			<xsd:element name="MinimumAccountSecurityLevel" type="xsd:nonPositiveInteger" >
 				<xsd:annotation>
 					<xsd:documentation>Required (minimum) sequrity level of any account that should hold a FareContract representing this product. The value is specified as a negative number, 0 is the highest level of security (most secure).  </xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
Added SecurityPolicy parameter in order to specify security requirements related to account based ticketing. Representing as a UsageParameter ensures possibility to set securityLevel on FareProduct as well as SalesOfferPackage, using LimitingRules and combine with other parameters, e.g. StepLimit. 