### PR TITLE
Update DatedServiceJourney definition

### DIFF
--- a/xsd/NeTEx_publication.xsd
+++ b/xsd/NeTEx_publication.xsd
@@ -6921,7 +6921,7 @@ Correct COnstraints for PointOnRoute
 			<xsd:annotation>
 				<xsd:documentation>Every [VehicleJourney Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleJourney"/>
+			<xsd:selector xpath=".//netex:VehicleJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
@@ -6951,12 +6951,12 @@ Correct COnstraints for PointOnRoute
 		</xsd:unique>
 		<!-- =====Journey Key ========================== -->
 		<xsd:keyref name="Journey_KeyRef" refer="netex:Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef"/>
+			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef | .//netex:DatedVehicleJourneyRef | .//netex:NormalDatedJourneyRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney"/>
+			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/NeTEx_publication_timetable.xsd
+++ b/xsd/NeTEx_publication_timetable.xsd
@@ -5594,7 +5594,7 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 			<xsd:annotation>
 				<xsd:documentation>Every [VehicleJourney Id + Version] must be unique within document.</xsd:documentation>
 			</xsd:annotation>
-			<xsd:selector xpath=".//netex:VehicleJourney"/>
+			<xsd:selector xpath=".//netex:VehicleJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:unique>
@@ -5624,12 +5624,12 @@ Provides a general purose wrapper for NeTEx data content.</xsd:documentation>
 		</xsd:unique>
 		<!-- =====Journey Key ========================== -->
 		<xsd:keyref name="Journey_KeyRef" refer="netex:Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef| .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef"/>
+			<xsd:selector xpath=".//netex:ServiceJourneyRef | .//netex:VehicleJourneyRef | .//netex:TemplateServiceJourneyRef | .//netex:JourneyRef | .//netex:DeadRunRef | .//netex:FromJourneyRef | .//netex:ToJourneyRef | .//netex:DatedVehicleJourneyRef | .//netex:NormalDatedJourneyRef"/>
 			<xsd:field xpath="@ref"/>
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="Journey_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney| .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney"/>
+			<xsd:selector xpath=".//netex:ServiceJourney | .//netex:VehicleJourney | .//netex:DeadRun | .//netex:SpecialService | .//netex:TemplateServiceJourney | .//netex:DatedServiceJourney | .//netex:DatedVehicleJourney | .//netex:NormalDatedJourney"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd
@@ -33,7 +33,7 @@
 					<Requires>http://www.netex.org.uk/schemas/2.0/xsd/netex_framework/netex_genericFramework/netex_pointAndLinkSequence_support.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
- <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+					<Copyright>CEN, Crown Copyright 2009-2014</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -43,13 +43,13 @@
 				<Status>Version 1.0</Status>
 				<Subject>
 					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
-Air transport, Airports,
-Ports and maritime transport, Ferries (marine),
-Public transport, Bus services, Coach services, Bus stops and stations,
-Rail transport, Railway stations and track, Train services, Underground trains,
-Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
-Rail transport, Roads and Road transport
-</Category>
+						Air transport, Airports,
+						Ports and maritime transport, Ferries (marine),
+						Public transport, Bus services, Coach services, Bus stops and stations,
+						Rail transport, Railway stations and track, Train services, Underground trains,
+						Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+						Rail transport, Roads and Road transport
+					</Category>
 					<Project>CEN TC278 WG3 SG9.</Project>
 				</Subject>
 				<Title>NeTEx DATED VEHICLE JOURNEY identifier types.</Title>
@@ -65,7 +65,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="VehicleJourneyIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="DatedVehicleJourneyRef" type="DatedVehicleJourneyRefStructure" substitutionGroup="VehicleJourneyRef">
+	<xsd:element name="DatedVehicleJourneyRef" type="VehicleJourneyRefStructure" substitutionGroup="JourneyRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
@@ -91,7 +91,7 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:restriction base="DatedVehicleJourneyIdType"/>
 	</xsd:simpleType>
-	<xsd:element name="NormalDatedVehicleJourneyRef" type="NormalDatedVehicleJourneyRefStructure" substitutionGroup="DatedVehicleJourneyRef">
+	<xsd:element name="NormalDatedVehicleJourneyRef" type="VehicleJourneyRefStructure" substitutionGroup="JourneyRef">
 		<xsd:annotation>
 			<xsd:documentation>Reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
@@ -101,7 +101,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for a reference to a NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:simpleContent>
-			<xsd:restriction base="DatedVehicleJourneyRefStructure">
+			<xsd:restriction base="VehicleJourneyRefStructure">
 				<xsd:attribute name="ref" type="NormalDatedVehicleJourneyIdType" use="required">
 					<xsd:annotation>
 						<xsd:documentation>Identifier of NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
@@ -133,34 +133,8 @@ Rail transport, Roads and Road transport
 			<xsd:enumeration value="other"/>
 		</xsd:restriction>
 	</xsd:simpleType>
-	<!-- === DATED SERVICE JOURNEY====================================================== -->
-	<xsd:simpleType name="DatedServiceJourneyIdType">
-		<xsd:annotation>
-			<xsd:documentation>Type for identifier of a DATED SERVICE JOURNEY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="ServiceJourneyIdType"/>
-	</xsd:simpleType>
-	<xsd:element name="DatedServiceJourneyRef" type="DatedServiceJourneyRefStructure" substitutionGroup="ServiceJourneyRef">
-		<xsd:annotation>
-			<xsd:documentation>Reference to a DATED SERVICE JOURNEY.</xsd:documentation>
-		</xsd:annotation>
-	</xsd:element>
-	<xsd:complexType name="DatedServiceJourneyRefStructure">
-		<xsd:annotation>
-			<xsd:documentation>Type for a reference to a DATED SERVICE JOURNEY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:restriction base="ServiceJourneyRefStructure">
-				<xsd:attribute name="ref" type="DatedServiceJourneyIdType" use="required">
-					<xsd:annotation>
-						<xsd:documentation>Identifier of DATED SERVICE JOURNEY.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:restriction>
-		</xsd:simpleContent>
-	</xsd:complexType>
 	<!-- ===DEAD RUN====================================================== -->
-	<!-- ===Special Service====================================================== -->
+	<!-- ===Service Journey====================================================== -->
 	<xsd:simpleType name="DatedSpecialServiceIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a DATED SPECIAL SERVICE.</xsd:documentation>

--- a/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
+++ b/xsd/netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_version.xsd
@@ -12,7 +12,6 @@
 				<Audience>e-service developers</Audience>
 				<Contributor>V1.0 Christophe Duquesne</Contributor>
 				<Contributor>Nicholas Knowles</Contributor>
-				<Contributor>Entur AS</Contributor>
 				<Coverage>Europe</Coverage>
 				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
 				<Date>
@@ -38,7 +37,7 @@
 					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile.xsd</Requires>
 				</Relation>
 				<Rights>Unclassified
-					 <Copyright>CEN, Crown Copyright 2009-2021</Copyright>
+					<Copyright>CEN, Crown Copyright 2009-2021</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -48,13 +47,13 @@
 				<Status>Version 1.0</Status>
 				<Subject>
 					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
-Air transport, Airports,
-Ports and maritime transport, Ferries (marine),
-Public transport, Bus services, Coach services, Bus stops and stations,
-Rail transport, Railway stations and track, Train services, Underground trains,
-Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
-Rail transport, Roads and Road transport
-</Category>
+						Air transport, Airports,
+						Ports and maritime transport, Ferries (marine),
+						Public transport, Bus services, Coach services, Bus stops and stations,
+						Rail transport, Railway stations and track, Train services, Underground trains,
+						Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+						Rail transport, Roads and Road transport
+					</Category>
 					<Project>CEN TC278 WG3 SG9.</Project>
 				</Subject>
 				<Title>NeTEx DATED VEHICLE JOURNE   types.</Title>
@@ -119,7 +118,7 @@ Rail transport, Roads and Road transport
 		</xsd:complexContent>
 	</xsd:complexType>
 	<!-- ======================================================================= -->
-	<xsd:element name="DatedVehicleJourney" abstract="false" substitutionGroup="VehicleJourney_">
+	<xsd:element name="DatedVehicleJourney" abstract="false" substitutionGroup="Journey_">
 		<xsd:annotation>
 			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.</xsd:documentation>
 		</xsd:annotation>
@@ -176,9 +175,14 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>PASSING TIMEs  for JOURNEY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="datedCalls" type="datedCalls_RelStructure" minOccurs="0">
+			<xsd:element name="datedCalls" type="calls_RelStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>DATED CALLs  for JOURNEY.</xsd:documentation>
+					<xsd:documentation>CALLs for JOURNEY.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>
@@ -188,18 +192,25 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Elements for DATED  VEHICLE JOURNEY REFERENCEs.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
-			<xsd:choice minOccurs="0" maxOccurs="unbounded">
-				<xsd:element ref="JourneyRef"/>
-			</xsd:choice>
-			<xsd:choice minOccurs="0">
-				<!-- OperatingDayRef NOT mandatory due to DatedServiceJourney backwards compatibility, was only mandatory for (Normal)DatedVehicleJourney -->
-				<xsd:element ref="OperatingDayRef"/>
-				<!-- Makes little sense referring to an OperatingPeriod for a Dated(x)Journey, but is kept for DatedServiceJourney backwards compatibility -->
-				<xsd:element ref="UicOperatingPeriod"/>
-			</xsd:choice>
+			<xsd:element ref="JourneyRef" minOccurs="0"/>
+			<xsd:element name="replacedJourneys" type="replacedJourneys_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>DATED VEHICLE JOURNEYs for which current VEHICLE JOURNEY is an alteration (i.e. change, replacement, supplement)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="OperatingDayRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>EXPECTED TO BE MANDATORY - left with minOccurs="0" only to avoid breaking compatibility with old rail datasets</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="UicOperatingPeriod" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>** DEPRECATED ** not to be used - left available only to avoid breaking compatibility with old rail datasets</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="ExternalDatedVehicleJourneyRef" type="ExternalObjectRefStructure" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>An alternative code that uniquely identifies the DATED VEHICLE JOURNEY. Specifically for use in AVMS systems. For VDV compatibility.</xsd:documentation>
+					<xsd:documentation>An alternative  code that uniquely identifies theDATED  VEHICLE  JOURNEY. Specifically for use in AVMS systems. For VDV compatibility.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="DatedJourneyPatternRef" type="JourneyPatternRefStructure" minOccurs="0">
@@ -207,11 +218,79 @@ Rail transport, Roads and Road transport
 					<xsd:documentation>Reference to a JOURNEY PATTERN.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element ref="DriverRef" minOccurs="0"/>
+			<xsd:element ref="DriverRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>** DEPRECATED ** not to be used - It is expected that the driver's DUTY refer the DatedJourneyPattern, not the way arround !</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="replacedJourneys_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of (NORMAL) DATED VEHICLE JOURNEY references.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DatedVehicleJourneyRef" maxOccurs="1"/>
+					<xsd:element ref="NormalDatedVehicleJourneyRef" maxOccurs="1"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ====DATED SERVICE JOURNEY====================================-->
+	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
+		<xsd:annotation>
+			<xsd:documentation>A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.
+
+				The VIEW includes derived ancillary data from referenced entities.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DatedServiceJourney_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="LinkSequenceGroup"/>
+						</xsd:sequence>
+						<xsd:group ref="JourneyGroup"/>
+						<xsd:group ref="ServiceJourneyGroup"/>
+						<xsd:sequence>
+							<xsd:group ref="DatedServiceJourneyGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DatedVehicleJourneyIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DatedServiceJourney_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Data type for Planned VEHICLE JOURNEY (Production Timetable Service).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ServiceJourney_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="DatedServiceJourneyGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DatedServiceJourneyGroup">
+		<xsd:annotation>
+			<xsd:documentation>If the journey is an alteration to a timetable, indicates the original journey, and the nature of the difference.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="DatedVehicleJourneyReferencesGroup"/>
 		</xsd:sequence>
 	</xsd:group>
 	<!-- ======================================================================= -->
-	<xsd:element name="NormalDatedVehicleJourney" abstract="false" substitutionGroup="VehicleJourney_">
+	<xsd:element name="NormalDatedVehicleJourney" abstract="false" substitutionGroup="Journey_">
 		<xsd:annotation>
 			<xsd:documentation>A DATED VEHICLE JOURNEY identical to a long-term planned VEHICLE JOURNEY, possibly updated according to short-term modifications of the PRODUCTION PLAN decided by the control staff.</xsd:documentation>
 		</xsd:annotation>
@@ -235,11 +314,8 @@ Rail transport, Roads and Road transport
 						<xsd:sequence>
 							<xsd:group ref="DatedVehicleJourneyGroup"/>
 						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="NormalDatedVehicleJourneyGroup"/>
-						</xsd:sequence>
 					</xsd:sequence>
-					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="optional">
+					<xsd:attribute name="id" type="NormalDatedVehicleJourneyIdType" use="required">
 						<xsd:annotation>
 							<xsd:documentation>Identifier of NORMAL DATED VEHICLE JORUNEY.</xsd:documentation>
 						</xsd:annotation>
@@ -253,62 +329,7 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>Type for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DatedVehicleJourney_VersionStructure">
-				<xsd:sequence>
-					<xsd:group ref="NormalDatedVehicleJourneyGroup"/>
-				</xsd:sequence>
-			</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
-	<xsd:group name="NormalDatedVehicleJourneyGroup">
-		<xsd:annotation>
-			<xsd:documentation>Elements for NORMAL DATED VEHICLE JOURNEY.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="ServiceAlterationType" type="ServiceAlterationEnumeration" default="planned" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>Type of Service alteration. Default is planned.</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
-		</xsd:sequence>
-	</xsd:group>
-	<!-- ======================================================================= -->
-	<xsd:element name="DatedServiceJourney" abstract="false" substitutionGroup="ServiceJourney_">
-		<xsd:annotation>
-			<xsd:documentation>A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.
-
-				The VIEW includes derived ancillary data from referenced entities.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:restriction base="DatedServiceJourney_VersionStructure">
-					<xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="DataManagedObjectGroup"/>
-						</xsd:sequence>
-						<xsd:sequence>
-							<xsd:group ref="LinkSequenceGroup"/>
-						</xsd:sequence>
-						<xsd:group ref="JourneyGroup"/>
-						<xsd:group ref="ServiceJourneyGroup"/>
-						<xsd:sequence>
-							<xsd:group ref="DatedVehicleJourneyGroup"/>
-						</xsd:sequence>
-					</xsd:sequence>
-					<xsd:attribute name="id" type="DatedServiceJourneyIdType"/>
-				</xsd:restriction>
-			</xsd:complexContent>
-		</xsd:complexType>
-	</xsd:element>
-	<xsd:complexType name="DatedServiceJourney_VersionStructure" abstract="false">
-		<xsd:annotation>
-			<xsd:documentation>Data type for DATED SERVICE JOURNEY (Production Timetable Service).</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-			<xsd:extension base="ServiceJourney_VersionStructure">
+			<xsd:extension base="VehicleJourney_VersionStructure">
 				<xsd:sequence>
 					<xsd:group ref="DatedVehicleJourneyGroup"/>
 				</xsd:sequence>
@@ -345,9 +366,9 @@ Rail transport, Roads and Road transport
 										<xsd:documentation>PASSING TIMEs  for JOURNEY.</xsd:documentation>
 									</xsd:annotation>
 								</xsd:element>
-								<xsd:element name="datedCalls" type="datedCalls_RelStructure" minOccurs="0">
+								<xsd:element name="datedCalls" type="calls_RelStructure" minOccurs="0">
 									<xsd:annotation>
-										<xsd:documentation>DATED CALLs  for JOURNEY.</xsd:documentation>
+										<xsd:documentation>CALLs for JOURNEY.</xsd:documentation>
 									</xsd:annotation>
 								</xsd:element>
 							</xsd:sequence>


### PR DESCRIPTION
This pull request aligns the definition of `DatedServiceJourneys` with the one defined in the CEN upstream repository.
The main change is the addition of the optional` <replacedJourneys>` element that contains a list of `DatedVehicleJourneyRef`. This list represents journeys that are replaced by the given DSJ.
In the context of the Nordic NeTEx profile, the replaced journeys are always references to `DatedServiceJourney`.
`DatedServiceJourney` is a subtype of `DatedVehicleJourney`

In the previous model, references to replaced DSJ where specified directly in the body of the `DatedServiceJourney` element, without any wrapper element.

Example:

Previous model:

```
<DatedServiceJourney version="1" id="VYG:DatedServiceJourney:96_KMB-NK_23-12-09">
     <ServiceJourneyRef ref="VYG:ServiceJourney:96-KMB_87815-R" version="11"></ServiceJourneyRef>
     <DatedServiceJourneyRef ref="VYG:DatedServiceJourney:8916_KVG-DEG_23-10-19" version="1"/>
     <OperatingDayRef ref="VYG:OperatingDay:2023-12-09"/>
 </DatedServiceJourney>
```

New model:

```
<DatedServiceJourney version="1" id="VYG:DatedServiceJourney:96_KMB-NK_23-12-09">
     <ServiceJourneyRef ref="VYG:ServiceJourney:96-KMB_87815-R" version="11"></ServiceJourneyRef>
     <OperatingDayRef ref="VYG:OperatingDay:2023-12-09"/>
     <replacedJourneys>
         <DatedVehicleJourneyRef ref="VYG:DatedServiceJourney:8916_KVG-DEG_23-10-19" version="1"/>
     </replacedJourneys>
 </DatedServiceJourney>
```
