### PR TITLE
Fix passenger information equipment list (#510)

### DIFF
--- a/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
+++ b/xsd/netex_framework/netex_reusableComponents/netex_facility_version.xsd
@@ -196,7 +196,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="MobilityFacilityList" minOccurs="0"/>
 			<xsd:element ref="NuisanceFacilityList" minOccurs="0"/>
 			<xsd:element ref="PassengerCommsFacilityList" minOccurs="0"/>
-			<xsd:element name="PassengerInformationEquipmentList" type="PassengerInformationEquipmentEnumeration" minOccurs="0">
+			<xsd:element name="PassengerInformationEquipmentList" type="PassengerInformationEquipmentListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>List of PASSENGER INFORMATION Equipments.</xsd:documentation>
 				</xsd:annotation>
@@ -245,7 +245,7 @@ Rail transport, Roads and Road transport
 			<xsd:element ref="MobilityFacilityList" minOccurs="0"/>
 			<xsd:element ref="NuisanceFacilityList" minOccurs="0"/>
 			<xsd:element ref="PassengerCommsFacilityList" minOccurs="0"/>
-			<xsd:element name="PassengerInformationEquipmentList" type="PassengerInformationEquipmentEnumeration" minOccurs="0">
+			<xsd:element name="PassengerInformationEquipmentList" type="PassengerInformationEquipmentListOfEnumerations" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>List of PASSENGER INFORMATION Equipments.</xsd:documentation>
 				</xsd:annotation>
@@ -1098,6 +1098,13 @@ Rail transport, Roads and Road transport
 			<xsd:documentation>List of values for NUISANCE FACILITY.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:list itemType="NuisanceFacilityEnumeration"/>
+	</xsd:simpleType>
+	<!-- ===PASSENGER INFORMATION EQUIPMENT ====================================== -->
+	<xsd:simpleType name="PassengerInformationEquipmentListOfEnumerations">
+		<xsd:annotation>
+			<xsd:documentation>List of values for PASSENGER INFORMATION EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:list itemType="PassengerInformationEquipmentEnumeration"/>
 	</xsd:simpleType>
 	<!-- ===Parking FACILITY====================================== -->
 	<xsd:element name="ParkingFacility" type="ParkingFacilityEnumeration">

--- a/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
+++ b/xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd
@@ -240,10 +240,15 @@ LOGICAL DISPLAY corresponds to a SIRI STOP MONITORING point.</xsd:documentation>
 			<xsd:element ref="LogicalDisplayRef" minOccurs="0"/>
 			<xsd:element ref="StopPlaceRef" minOccurs="0"/>
 			<xsd:element ref="SiteComponentRef" minOccurs="0"/>
+			<xsd:element name="PassengerInformationEquipmentList" type="PassengerInformationEquipmentListOfEnumerations" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>List of PASSENGER INFORMATION Equipments.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="TypeOfPassengerInformationEquipmentRef" minOccurs="0"/>
 			<xsd:element ref="PassengerInformationFacilityList" minOccurs="0">
 				<xsd:annotation>
-					<xsd:documentation>List of predefined Passenger Info EQUIPMENT f.</xsd:documentation>
+					<xsd:documentation>List of predefined Passenger Info EQUIPMENT.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element ref="AccessibilityInfoFacilityList" minOccurs="0"/>


### PR DESCRIPTION
* The connection exists in the documentation, but was not done in the xsd

NeTEx part 1, figure 628

* Fixed according to Christophe's proposal

* Apply suggestions from code review

* Update xsd/netex_part_1/part1_tacticalPlanning/netex_passengerInformationEquipment_version.xsd

* Lint and update documentation tables

---------