### PR TITLE
Add DatedVehicleJourneyRefs as alternatives to ServiceJourneyRefs where DSJRefs in current use

### DIFF
--- a/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
+++ b/xsd/netex_part_3/part3_fares/netex_accessRightParameter_version.xsd
@@ -11,6 +11,7 @@
 	<xsd:include schemaLocation="../../netex_part_1/part1_networkDescription/netex_route_support.xsd"/>
 	<!-- ====Timetables ========================================================= -->
 	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd"/>
+	<xsd:include schemaLocation="../../netex_part_2/part2_journeyTimes/netex_datedVehicleJourney_support.xsd"/>
 	<!-- ====Fares ========================================================= -->
 	<xsd:include schemaLocation="netex_validableElement_support.xsd"/>
 	<xsd:include schemaLocation="netex_qualityStructureFactor_support.xsd"/>
@@ -533,6 +534,9 @@ Rail transport, Roads and Road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="ServiceJourneyRef" minOccurs="0"/>
+			<xsd:element ref="SpecialServiceRef" minOccurs="0"/>
+			<xsd:element ref="DatedVehicleJourneyRef" minOccurs="0"/>
+			<xsd:element ref="NormalDatedVehicleJourneyRef" minOccurs="0"/>
 			<xsd:element ref="TrainNumberRef" minOccurs="0"/>
 			<xsd:element ref="GroupOfServicesRef" minOccurs="0"/>
 		</xsd:sequence>

--- a/xsd/netex_part_3/part3_salesTransactions/netex_fareContract_logentries_version.xsd
+++ b/xsd/netex_part_3/part3_salesTransactions/netex_fareContract_logentries_version.xsd
@@ -166,6 +166,11 @@
 					<xsd:documentation>The ServiceJourney where this control was conducted</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element ref="DatedVehicleJourneyRef" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The DatedVehicleJourney where this control was conducted</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
 	<xsd:group name="DeviceRelatedControlMeansGroup">


### PR DESCRIPTION
Two changes allowing us to move to 2.0.16 version for Entur/NeTEx without creating tmp solutions that will not work with 2.0.

1. Allowing SpecialServiceRef/DatedVehicleJourneyRef/NormalDatedVehicleJourneyRef 
This lifted directly from CEN 2.0. 

2. netex_fareContract_logentries_version.xsd is local change to Entur NeTEx and does not exist in CEN NeTEx. We will have to sort out how to handle this and other changes before moving to 3.0.0, but for now adding a DatedVehicleJourneyRef as a substitution for the removed DatedServiceJourney previously allowed as a substitute for ServiceJourney will make the migration a lot easier for us.

